### PR TITLE
34: allowing to extend FulfillmentCenterSearchService by adding new fields to the search criteria

### DIFF
--- a/VirtoCommerce.InventoryModule.Data/Services/FulfillmentCenterSearchService.cs
+++ b/VirtoCommerce.InventoryModule.Data/Services/FulfillmentCenterSearchService.cs
@@ -39,7 +39,7 @@ namespace VirtoCommerce.InventoryModule.Data.Services
                 result.TotalCount = query.Count();
                 result.Results = query.Skip(criteria.Skip)
                                  .Take(criteria.Take)
-                                 .ToArray()
+                                 .AsEnumerable()
                                  .Select(x => x.ToModel(AbstractTypeFactory<FulfillmentCenter>.TryCreateInstance()))
                                  .ToList();
             }

--- a/VirtoCommerce.InventoryModule.Data/Services/FulfillmentCenterSearchService.cs
+++ b/VirtoCommerce.InventoryModule.Data/Services/FulfillmentCenterSearchService.cs
@@ -14,6 +14,7 @@ namespace VirtoCommerce.InventoryModule.Data.Services
     public class FulfillmentCenterSearchService : IFulfillmentCenterSearchService
     {
         private readonly Func<IInventoryRepository> _repositoryFactory;
+
         public FulfillmentCenterSearchService(Func<IInventoryRepository> repositoryFactory)
         {
             _repositoryFactory = repositoryFactory;
@@ -47,8 +48,8 @@ namespace VirtoCommerce.InventoryModule.Data.Services
             return result;
         }
 
-        protected virtual IQueryable<FulfillmentCenterEntity> GetFulfillmentCentersQuery(IInventoryRepository repository,
-            FulfillmentCenterSearchCriteria criteria)
+
+        protected virtual IQueryable<FulfillmentCenterEntity> GetFulfillmentCentersQuery(IInventoryRepository repository, FulfillmentCenterSearchCriteria criteria)
         {
             var query = repository.FulfillmentCenters;
 

--- a/VirtoCommerce.InventoryModule.Data/Services/FulfillmentCenterSearchService.cs
+++ b/VirtoCommerce.InventoryModule.Data/Services/FulfillmentCenterSearchService.cs
@@ -4,6 +4,7 @@ using VirtoCommerce.Domain.Commerce.Model.Search;
 using VirtoCommerce.Domain.Inventory.Model;
 using VirtoCommerce.Domain.Inventory.Model.Search;
 using VirtoCommerce.Domain.Inventory.Services;
+using VirtoCommerce.InventoryModule.Data.Model;
 using VirtoCommerce.InventoryModule.Data.Repositories;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Data.Infrastructure;
@@ -18,18 +19,14 @@ namespace VirtoCommerce.InventoryModule.Data.Services
             _repositoryFactory = repositoryFactory;
         }
 
-        public GenericSearchResult<FulfillmentCenter> SearchCenters(FulfillmentCenterSearchCriteria criteria)
+        public virtual GenericSearchResult<FulfillmentCenter> SearchCenters(FulfillmentCenterSearchCriteria criteria)
         {
             var result = new GenericSearchResult<FulfillmentCenter>();
             using (var repository = _repositoryFactory())
             {
                 repository.DisableChangesTracking();
 
-                var query = repository.FulfillmentCenters;
-                if (!string.IsNullOrEmpty(criteria.SearchPhrase))
-                {
-                    query = query.Where(x => x.Name.Contains(criteria.SearchPhrase));
-                }
+                var query = GetFulfillmentCentersQuery(repository, criteria);
 
                 var sortInfos = criteria.SortInfos;
                 if (sortInfos.IsNullOrEmpty())
@@ -47,6 +44,19 @@ namespace VirtoCommerce.InventoryModule.Data.Services
                                  .ToList();
             }
             return result;
+        }
+
+        protected virtual IQueryable<FulfillmentCenterEntity> GetFulfillmentCentersQuery(IInventoryRepository repository,
+            FulfillmentCenterSearchCriteria criteria)
+        {
+            var query = repository.FulfillmentCenters;
+
+            if (!string.IsNullOrEmpty(criteria.SearchPhrase))
+            {
+                query = query.Where(x => x.Name.Contains(criteria.SearchPhrase));
+            }
+
+            return query;
         }
     }
 }

--- a/VirtoCommerce.InventoryModule.Data/Services/FulfillmentCenterSearchService.cs
+++ b/VirtoCommerce.InventoryModule.Data/Services/FulfillmentCenterSearchService.cs
@@ -43,6 +43,7 @@ namespace VirtoCommerce.InventoryModule.Data.Services
                                  .Select(x => x.ToModel(AbstractTypeFactory<FulfillmentCenter>.TryCreateInstance()))
                                  .ToList();
             }
+
             return result;
         }
 

--- a/VirtoCommerce.InventoryModule.Data/Services/InventorySearchService.cs
+++ b/VirtoCommerce.InventoryModule.Data/Services/InventorySearchService.cs
@@ -14,6 +14,7 @@ namespace VirtoCommerce.InventoryModule.Data.Services
     public class InventorySearchService : IInventorySearchService
     {
         private readonly Func<IInventoryRepository> _repositoryFactory;
+
         public InventorySearchService(Func<IInventoryRepository> repositoryFactory)
         {
             _repositoryFactory = repositoryFactory;
@@ -47,8 +48,8 @@ namespace VirtoCommerce.InventoryModule.Data.Services
             return result;
         }
 
-        protected virtual IQueryable<InventoryEntity> GetInventoriesQuery(IInventoryRepository repository,
-            InventorySearchCriteria criteria)
+
+        protected virtual IQueryable<InventoryEntity> GetInventoriesQuery(IInventoryRepository repository, InventorySearchCriteria criteria)
         {
             var query = repository.Inventories;
 


### PR DESCRIPTION
* `FulfillmentCenterSearchService.Search()` method is now virtual, so that it can be overridden in derived classes.
* Database query building is done in a separate virtual method - `GetFulfillmentCentersQuery()`. Now derived classes can override that method and apply additional filters to the resulting query.
* Also, replaced redundant `.ToArray()` method in query materialization code with `.AsEnumerable()` (SonarLint marked that `.ToArray()` as an issue).