### PR TITLE
36: limiting widget columns count on FFC details blade

### DIFF
--- a/VirtoCommerce.InventoryModule.Web/Scripts/blades/fulfillment-center-detail.tpl.html
+++ b/VirtoCommerce.InventoryModule.Web/Scripts/blades/fulfillment-center-detail.tpl.html
@@ -31,7 +31,7 @@
                 <va-metaform blade="blade" registered-inputs="blade.metaFields"></va-metaform>
             </form>
 
-            <va-widget-container group="fulfillmentCenterDetail" blade="blade" gridster-opts="{width: 396}"></va-widget-container>
+            <va-widget-container group="fulfillmentCenterDetail" blade="blade" gridster-opts="{columns: 3}"></va-widget-container>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Details of this problem are explained in #36. This PR replaces width limit for widget container with widget columns count limit, so that new widgets can be properly wrapped to a new line.
![image](https://user-images.githubusercontent.com/1835759/65676751-a297cc80-e07a-11e9-9cd0-200c8799059a.png)
