### PR TITLE
HDOT-2288 Fix updating inventories if there are other inventory records for same product and FFC

### DIFF
--- a/src/VirtoCommerce.InventoryModule.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.InventoryModule.Core/ModuleConstants.cs
@@ -34,7 +34,19 @@ namespace VirtoCommerce.InventoryModule.Core
                     DefaultValue = "50",
                 };
 
-                public static IEnumerable<SettingDescriptor> AllSettings { get; } = new[] { PageSize };
+                public static SettingDescriptor LogInventoryChanges { get; } = new SettingDescriptor
+                {
+                    Name = "Inventory.LogInventoryChanges",
+                    GroupName = "Inventory | General",
+                    ValueType = SettingValueType.Boolean,
+                    DefaultValue = true,
+                };
+
+                public static IEnumerable<SettingDescriptor> AllSettings { get; } = new[]
+                {
+                    PageSize,
+                    LogInventoryChanges
+                };
             }
 
             public static class Search

--- a/src/VirtoCommerce.InventoryModule.Core/VirtoCommerce.InventoryModule.Core.csproj
+++ b/src/VirtoCommerce.InventoryModule.Core/VirtoCommerce.InventoryModule.Core.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.32.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.12.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.InventoryModule.Core/VirtoCommerce.InventoryModule.Core.csproj
+++ b/src/VirtoCommerce.InventoryModule.Core/VirtoCommerce.InventoryModule.Core.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.5.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.32.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.InventoryModule.Data/Handlers/LogChangesChangedEventHandler.cs
+++ b/src/VirtoCommerce.InventoryModule.Data/Handlers/LogChangesChangedEventHandler.cs
@@ -1,38 +1,53 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Hangfire;
+using VirtoCommerce.InventoryModule.Core;
 using VirtoCommerce.InventoryModule.Core.Events;
 using VirtoCommerce.Platform.Core.ChangeLog;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Events;
+using VirtoCommerce.Platform.Core.Settings;
 
 namespace VirtoCommerce.InventoryModule.Data.Handlers
 {
     public class LogChangesChangedEventHandler : IEventHandler<InventoryChangedEvent>
     {
         private readonly IChangeLogService _changeLogService;
+        private readonly ILastModifiedDateTime _lastModifiedDateTime;
+        private readonly ISettingsManager _settingsManager;
 
-        public LogChangesChangedEventHandler(IChangeLogService changeLogService)
+        public LogChangesChangedEventHandler(IChangeLogService changeLogService, ILastModifiedDateTime lastModifiedDateTime, ISettingsManager settingsManager)
         {
             _changeLogService = changeLogService;
+            _lastModifiedDateTime = lastModifiedDateTime;
+            _settingsManager = settingsManager;
         }
 
-        public virtual Task Handle(InventoryChangedEvent message)
+        public virtual async Task Handle(InventoryChangedEvent message)
         {
-            InnerHandle(message);
-            return Task.CompletedTask;
+            await InnerHandle(message);
         }
 
-        protected virtual void InnerHandle<T>(GenericChangedEntryEvent<T> @event) where T : IEntity
+        protected virtual async Task InnerHandle<T>(GenericChangedEntryEvent<T> @event) where T : IEntity
         {
-            var logOperations = @event.ChangedEntries.Select(x => AbstractTypeFactory<OperationLog>.TryCreateInstance().FromChangedEntry(x)).ToArray();
-            //Background task is used here for performance reasons
-            BackgroundJob.Enqueue(() => LogEntityChangesInBackground(logOperations));
+            var logInventoryChangesEnabled = await _settingsManager.GetValueAsync(ModuleConstants.Settings.General.LogInventoryChanges.Name, (bool)ModuleConstants.Settings.General.LogInventoryChanges.DefaultValue);
+
+            if (logInventoryChangesEnabled)
+            {
+                var logOperations = @event.ChangedEntries.Select(x => AbstractTypeFactory<OperationLog>.TryCreateInstance().FromChangedEntry(x)).ToArray();
+                //Background task is used here for performance reasons
+                BackgroundJob.Enqueue(() => LogEntityChangesInBackground(logOperations));
+            }
+            else
+            {
+                // Force reset the date of last data modifications, so that it would be reset even if the Inventory.LogInventoryChanges setting is inactive.
+                _lastModifiedDateTime.Reset();
+            }
         }
 
-        public void LogEntityChangesInBackground(OperationLog[] operationLogs)
+        public async Task LogEntityChangesInBackground(OperationLog[] operationLogs)
         {
-            _changeLogService.SaveChangesAsync(operationLogs).GetAwaiter().GetResult();
+            await _changeLogService.SaveChangesAsync(operationLogs);
         }
     }
 }

--- a/src/VirtoCommerce.InventoryModule.Data/VirtoCommerce.InventoryModule.Data.csproj
+++ b/src/VirtoCommerce.InventoryModule.Data/VirtoCommerce.InventoryModule.Data.csproj
@@ -10,19 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Hangfire" Version="1.7.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.2" />
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.5.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.32.0" />
     <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1.0" />
     <PackageReference Include="VirtoCommerce.SearchModule.Data" Version="3.1.0" />
   </ItemGroup>

--- a/src/VirtoCommerce.InventoryModule.Data/VirtoCommerce.InventoryModule.Data.csproj
+++ b/src/VirtoCommerce.InventoryModule.Data/VirtoCommerce.InventoryModule.Data.csproj
@@ -10,8 +10,19 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Hangfire" Version="1.7.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.2">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.2">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.2" />
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.32.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.12.0" />
     <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1.0" />
     <PackageReference Include="VirtoCommerce.SearchModule.Data" Version="3.1.0" />
   </ItemGroup>

--- a/src/VirtoCommerce.InventoryModule.Data/VirtoCommerce.InventoryModule.Data.csproj
+++ b/src/VirtoCommerce.InventoryModule.Data/VirtoCommerce.InventoryModule.Data.csproj
@@ -12,12 +12,12 @@
     <PackageReference Include="Hangfire" Version="1.7.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.2">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.2">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.2" />

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/en.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/en.VirtoCommerce.Inventory.json
@@ -92,9 +92,13 @@
     },
     "settings": {
       "Inventory": {
-        "ExportImport.PageSize" :{
+        "ExportImport.PageSize": {
           "description": "High value may will cause slow performance",
           "title": "The page size being used for Export / Import"
+        },
+        "LogInventoryChanges": {
+          "title": "Log inventory changes",
+          "description": "Log product stock changes into the platform operation log. This might impact database size if product stocks are changed relatively often."
         },
         "Search": {
           "EventBasedIndexation": {

--- a/src/VirtoCommerce.InventoryModule.Web/module.manifest
+++ b/src/VirtoCommerce.InventoryModule.Web/module.manifest
@@ -3,7 +3,7 @@
   <id>VirtoCommerce.Inventory</id>
   <version>3.9.0</version>
   <version-tag />
-  <platformVersion>3.32.0</platformVersion>
+  <platformVersion>3.12.0</platformVersion>
   <title>Inventory module</title>
   <description>Simplify inventory management functionality</description>
   <authors>

--- a/src/VirtoCommerce.InventoryModule.Web/module.manifest
+++ b/src/VirtoCommerce.InventoryModule.Web/module.manifest
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <id>VirtoCommerce.Inventory</id>
   <version>3.9.0</version>
   <version-tag />
-  <platformVersion>3.5.0</platformVersion>
+  <platformVersion>3.32.0</platformVersion>
   <title>Inventory module</title>
   <description>Simplify inventory management functionality</description>
   <authors>


### PR DESCRIPTION
https://virtocommerce.atlassian.net/browse/HDOT-2288

Main feature of this PR is a fix for inventory saving if the database contains other inventories for same product and FFC. Suppose that there are two inventories in the `Inventory` table for product `product1` and FFC `ffc1` - `I1` and `I2`. Also, please consider the code that handles these inventories (only to demonstrate the nature of this issue):
```cs
var searchCriteria = new InventorySearchCriteria
{
    FulfillmentCenterIds = new[] { "ffc1" },
    ProductIds = new[] { "product1" },
    // ... some other criteria ...
    Take = 1,
};

bool inventoriesFound;
do
{
    var searchResult = await _inventorySearchService.SearchAsync(searchCriteria);

    var inventories = searchResult.Results;
    inventoriesFound = inventories.Any();

    if (inventoriesFound)
    {
        foreach (var inventory in inventories)
        {
            // The following line modifies the inventory (without changing target FFC or product), 
            // so that it no longer would match the searchCriteria
            DoSomethingWithInventory(inventory);
        }

        await _inventoryService.SaveChangesAsync(inventories);
    }
}
while (inventoriesFound);
```

Here is what could happen here:
1. First iteration:
    1. The code looks for inventories matching the search criteria. There are two matching inventories in the database (`I1` and `I2`), and the inventory search returns the inventory `I1`.
    2. The code modifies that inventory and attempts to save it.
    3. The `InventoryServiceImpl` looks for existing inventories in the database, but for some reason gets the `I2` inventory closer to the beginning of the list. So it patches the `I2` entity with properties of `I1` and saves it to the database.
2. Second iteration:
    1. The code looks for inventories again. At this point there is only one inventory that matches search criteria (`I1`), so the inventory search returns it.
    2. The code modifies it again and attempts to save it.
    3. The `InventoryServiceImpl` looks for existing inventories in the database, gets `I2` again, modifies it and saves to the database. Changes of `I1` do not get saved, and it still matches the search criteria.
3. From this point, all of the following iterations will be same as iteration 2, and this loop will never break.

To fix this issue, I modified the code that resolves existing entities in the `SaveChangesAsync` method. Now it will always attempt to find matching entity by ID, and if such entity was not found (i.e. if the inventory being saved is transient, or if the database entity of that inventory got removed), it will attempt to find matching entity by (product ID, FFC ID). This way, this method will always attempt to patch the exact entry that was passed to the `SaveChangesAsync()` method.

Also, this PR contains some side changes:
1. There is now a setting that allows to disable the change log for inventories. This should offload the `Hangfire` queue and reduce the size of `PlatformOperationLog` table for projects where there are lots of inventories (e.g. multiple FFCs with several hundreds of products in each), and these inventories are regularly updated (e.g. hourly by some integrations). By default this setting is enabled, so that the behavior will remain the same for other projects.
![image](https://user-images.githubusercontent.com/1835759/99420567-ee1cd200-292f-11eb-9cc9-eedc60721111.png)
2. If that setting is disabled, the `LogChangesChangedEventHandler` should still reset the date of last data changes (to reset the storefront cache). However, this module previously referenced the platform 3.5.0, and the `ILastModifiedDateTime` service was introduced later. So, I updated the referenced platform version - now this module references the latest release version of platform (3.32.0).
3. The `VirtoCommerce.InventoryModule.Data` project referenced the `VirtoCommerce.Platform.Data`, which already references the `Microsoft.EntityFrameworkCore`. So, IMO, there is no need to add explicit references for EF Core - all of the required assemblies and tools will still be installed through the `VirtoCommerce.Platform.Data`.