### PR TITLE
VP-6815: Add ModifiedDate to the index by SKU in Inventory table

### DIFF
--- a/src/VirtoCommerce.InventoryModule.Data/Migrations/20210203052718_AddInventorySkuModifiedDateIndex.Designer.cs
+++ b/src/VirtoCommerce.InventoryModule.Data/Migrations/20210203052718_AddInventorySkuModifiedDateIndex.Designer.cs
@@ -190,8 +190,7 @@ namespace VirtoCommerce.InventoryModule.Data.Migrations
                     b.HasOne("VirtoCommerce.InventoryModule.Data.Model.FulfillmentCenterEntity", "FulfillmentCenter")
                         .WithMany()
                         .HasForeignKey("FulfillmentCenterId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+                        .OnDelete(DeleteBehavior.Cascade);
                 });
 #pragma warning restore 612, 618
         }

--- a/src/VirtoCommerce.InventoryModule.Data/Migrations/20210203052718_AddInventorySkuModifiedDateIndex.Designer.cs
+++ b/src/VirtoCommerce.InventoryModule.Data/Migrations/20210203052718_AddInventorySkuModifiedDateIndex.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VirtoCommerce.InventoryModule.Data.Repositories;
 
 namespace VirtoCommerce.InventoryModule.Data.Migrations
 {
     [DbContext(typeof(InventoryDbContext))]
-    partial class InventoryDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210203052718_AddInventorySkuModifiedDateIndex")]
+    partial class AddInventorySkuModifiedDateIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -188,7 +190,8 @@ namespace VirtoCommerce.InventoryModule.Data.Migrations
                     b.HasOne("VirtoCommerce.InventoryModule.Data.Model.FulfillmentCenterEntity", "FulfillmentCenter")
                         .WithMany()
                         .HasForeignKey("FulfillmentCenterId")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });
 #pragma warning restore 612, 618
         }

--- a/src/VirtoCommerce.InventoryModule.Data/Migrations/20210203052718_AddInventorySkuModifiedDateIndex.cs
+++ b/src/VirtoCommerce.InventoryModule.Data/Migrations/20210203052718_AddInventorySkuModifiedDateIndex.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace VirtoCommerce.InventoryModule.Data.Migrations
+{
+    public partial class AddInventorySkuModifiedDateIndex : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Inventory_Sku",
+                table: "Inventory");
+
+            // Add index thru scripting because of no way to make indexing field DESC
+            migrationBuilder.Sql(@"CREATE INDEX [IX_Inventory_Sku_ModifiedDate] ON [Inventory] ([Sku] ASC, [ModifiedDate] DESC)");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Inventory_Sku_ModifiedDate",
+                table: "Inventory");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Inventory_Sku",
+                table: "Inventory",
+                column: "Sku");
+        }
+    }
+}

--- a/src/VirtoCommerce.InventoryModule.Data/Migrations/20210203052718_AddInventorySkuModifiedDateIndex.cs
+++ b/src/VirtoCommerce.InventoryModule.Data/Migrations/20210203052718_AddInventorySkuModifiedDateIndex.cs
@@ -6,9 +6,7 @@ namespace VirtoCommerce.InventoryModule.Data.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropIndex(
-                name: "IX_Inventory_Sku",
-                table: "Inventory");
+            migrationBuilder.Sql(@"DROP INDEX IF EXISTS [IX_Inventory_Sku] ON [Inventory]");
 
             // Add index thru scripting because of no way to make indexing field DESC
             migrationBuilder.Sql(@"CREATE INDEX [IX_Inventory_Sku_ModifiedDate] ON [Inventory] ([Sku] ASC, [ModifiedDate] DESC)");

--- a/src/VirtoCommerce.InventoryModule.Data/Repositories/InventoryDbContext.cs
+++ b/src/VirtoCommerce.InventoryModule.Data/Repositories/InventoryDbContext.cs
@@ -20,7 +20,7 @@ namespace VirtoCommerce.InventoryModule.Data.Repositories
         {
             modelBuilder.Entity<InventoryEntity>().ToTable("Inventory").HasKey(x => x.Id);
             modelBuilder.Entity<InventoryEntity>().Property(x => x.Id).HasMaxLength(128).ValueGeneratedOnAdd();
-            modelBuilder.Entity<InventoryEntity>().HasIndex(inv => new { inv.Sku }).IsUnique(false);
+            modelBuilder.Entity<InventoryEntity>().HasIndex(inv => new { inv.Sku, inv.ModifiedDate /* (! Important !) DESC */ }).IsUnique(false).HasName("IX_Inventory_Sku_ModifiedDate");
             modelBuilder.Entity<InventoryEntity>().HasOne(x => x.FulfillmentCenter).WithMany()
                 .HasForeignKey(x => x.FulfillmentCenterId).IsRequired()
                 .OnDelete(DeleteBehavior.Cascade);


### PR DESCRIPTION
Adding line items to the cart gives us statements like this:
``` SQL
exec sp_executesql N'SELECT [i].[Id]  FROM [Inventory] AS [I]  
WHERE [i].[Sku] IN (N''2FBFF9B5-3572-4F45-BE69-FF9F9E332F83'', N''1D041EC6-4081-4A07-A395-926766D38FBE'')  
ORDER BY [i].[ModifiedDate] DESC, [i].[Id]  
OFFSET @__p_1 ROWS FETCH NEXT @__p_2 ROWS ONLY',N'@__p_1 int,@__p_2 int',@__p_1=0,@__p_2=20
```
Let's add this index to:
1. Disable cluster index lookup for ModifiedDate.
2. Simplify ordering by ModifiedDate.