### PR TITLE
VCST-5163: Stable 15 — Inventory (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.InventoryModule.Core/VirtoCommerce.InventoryModule.Core.csproj
+++ b/src/VirtoCommerce.InventoryModule.Core/VirtoCommerce.InventoryModule.Core.csproj
@@ -15,8 +15,8 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1023.0" />
-    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1007.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1004.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.InventoryModule.Data.MySql/VirtoCommerce.InventoryModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.InventoryModule.Data.MySql/VirtoCommerce.InventoryModule.Data.MySql.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1023.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.InventoryModule.Data\VirtoCommerce.InventoryModule.Data.csproj" />

--- a/src/VirtoCommerce.InventoryModule.Data.PostgreSql/VirtoCommerce.InventoryModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.InventoryModule.Data.PostgreSql/VirtoCommerce.InventoryModule.Data.PostgreSql.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1023.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.InventoryModule.Data\VirtoCommerce.InventoryModule.Data.csproj" />

--- a/src/VirtoCommerce.InventoryModule.Data.SqlServer/VirtoCommerce.InventoryModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.InventoryModule.Data.SqlServer/VirtoCommerce.InventoryModule.Data.SqlServer.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1023.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.InventoryModule.Data\VirtoCommerce.InventoryModule.Data.csproj" />

--- a/src/VirtoCommerce.InventoryModule.Data/ExportImport/InventoryExportImport.cs
+++ b/src/VirtoCommerce.InventoryModule.Data/ExportImport/InventoryExportImport.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+
 using System.Threading;
 using System.IO;
 using System.Text;
@@ -43,9 +44,9 @@ public sealed class InventoryExportImport(
 
         await using var streamWriter = new StreamWriter(outStream, Encoding.UTF8);
         await using var writer = new JsonTextWriter(streamWriter);
-        await writer.WriteStartObjectAsync();
+        await writer.WriteStartObjectAsync(cancellationToken);
 
-        await writer.WritePropertyNameAsync("FulfillmentCenters");
+        await writer.WritePropertyNameAsync("FulfillmentCenters", cancellationToken);
         await writer.SerializeArrayWithPagingAsync(jsonSerializer, BatchSize, async (skip, take) =>
         {
             var searchCriteria = AbstractTypeFactory<FulfillmentCenterSearchCriteria>.TryCreateInstance();
@@ -62,7 +63,7 @@ public sealed class InventoryExportImport(
         progressInfo.Description = "The Inventories are loading";
         progressCallback(progressInfo);
 
-        await writer.WritePropertyNameAsync("Inventories");
+        await writer.WritePropertyNameAsync("Inventories", cancellationToken);
         await writer.SerializeArrayWithPagingAsync(jsonSerializer, BatchSize, async (skip, take) =>
         {
             var searchCriteria = AbstractTypeFactory<InventorySearchCriteria>.TryCreateInstance();
@@ -76,8 +77,8 @@ public sealed class InventoryExportImport(
             progressCallback(progressInfo);
         }, cancellationToken);
 
-        await writer.WriteEndObjectAsync();
-        await writer.FlushAsync();
+        await writer.WriteEndObjectAsync(cancellationToken);
+        await writer.FlushAsync(cancellationToken);
     }
 
     public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
@@ -88,7 +89,7 @@ public sealed class InventoryExportImport(
 
         using var streamReader = new StreamReader(inputStream);
         await using var reader = new JsonTextReader(streamReader);
-        while (await reader.ReadAsync())
+        while (await reader.ReadAsync(cancellationToken))
         {
             if (reader.TokenType == JsonToken.PropertyName && reader.Value != null)
             {

--- a/src/VirtoCommerce.InventoryModule.Data/ExportImport/InventoryExportImport.cs
+++ b/src/VirtoCommerce.InventoryModule.Data/ExportImport/InventoryExportImport.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -33,7 +34,7 @@ public sealed class InventoryExportImport(
         }
     }
 
-    public async Task DoExportAsync(Stream outStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+    public async Task DoExportAsync(Stream outStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -79,7 +80,7 @@ public sealed class InventoryExportImport(
         await writer.FlushAsync();
     }
 
-    public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+    public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/VirtoCommerce.InventoryModule.Data/VirtoCommerce.InventoryModule.Data.csproj
+++ b/src/VirtoCommerce.InventoryModule.Data/VirtoCommerce.InventoryModule.Data.csproj
@@ -15,8 +15,8 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1023.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1023.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.InventoryModule.Core\VirtoCommerce.InventoryModule.Core.csproj" />

--- a/src/VirtoCommerce.InventoryModule.Web/Module.cs
+++ b/src/VirtoCommerce.InventoryModule.Web/Module.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -135,12 +136,12 @@ namespace VirtoCommerce.InventoryModule.Web
             // Method intentionally left empty.
         }
 
-        public async Task ExportAsync(Stream outStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public async Task ExportAsync(Stream outStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             await _appBuilder.ApplicationServices.GetRequiredService<InventoryExportImport>().DoExportAsync(outStream, progressCallback, cancellationToken);
         }
 
-        public async Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public async Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             await _appBuilder.ApplicationServices.GetRequiredService<InventoryExportImport>().DoImportAsync(inputStream, progressCallback, cancellationToken);
         }

--- a/src/VirtoCommerce.InventoryModule.Web/module.manifest
+++ b/src/VirtoCommerce.InventoryModule.Web/module.manifest
@@ -4,11 +4,11 @@
   <version>3.1003.0</version>
   <version-tag />
 
-  <platformVersion>3.1023.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Catalog" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Core" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Search" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Catalog" version="3.1029.0" />
+    <dependency id="VirtoCommerce.Core" version="3.1007.0" />
+    <dependency id="VirtoCommerce.Search" version="3.1004.0" />
   </dependencies>
 
   <title>Inventory</title>


### PR DESCRIPTION
Part of **Stable 15** (Wave 5). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Wave 1–4 packages on nuget.org. Version handled by CI.

- ICT migration. (12 cascading interface-method obsoletes deferred.)
- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Export/import cancellation and dependency upgrades affect bulk data operations; behavior should match platform but warrants smoke-testing import/export jobs.
> 
> **Overview**
> Bumps **Virto Commerce** package references and `module.manifest` to **platform 3.1039.0** and updated Catalog, Core, and Search dependency versions for Stable 15.
> 
> Completes the **ICT migration** by replacing `ICancellationToken` with `System.Threading.CancellationToken` on module export/import and in `InventoryExportImport`. JSON export/import now passes `cancellationToken` into `JsonTextWriter` / `JsonTextReader` async calls so long-running jobs honor cancellation consistently with the new platform APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7598234055d1ffca113dceeafe11378639d26f25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Inventory_3.1003.0-pr-161-7598.zip