### PR TITLE
VCST-5328: Make GetDocumentsAsync virtual in ProductAvailabilityDocumentBuilder

### DIFF
--- a/src/VirtoCommerce.InventoryModule.Data/Search/Indexing/ProductAvailabilityDocumentBuilder.cs
+++ b/src/VirtoCommerce.InventoryModule.Data/Search/Indexing/ProductAvailabilityDocumentBuilder.cs
@@ -26,7 +26,7 @@ public class ProductAvailabilityDocumentBuilder(IInventorySearchService inventor
         return Task.CompletedTask;
     }
 
-    public async Task<IList<IndexDocument>> GetDocumentsAsync(IList<string> documentIds)
+    public virtual async Task<IList<IndexDocument>> GetDocumentsAsync(IList<string> documentIds)
     {
         var now = DateTime.UtcNow;
         var result = new List<IndexDocument>();

--- a/tests/VirtoCommerce.InventoryModule.Tests/ProductAvailabilityDocumentBuilderTests.cs
+++ b/tests/VirtoCommerce.InventoryModule.Tests/ProductAvailabilityDocumentBuilderTests.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using VirtoCommerce.InventoryModule.Core.Services;
+using VirtoCommerce.InventoryModule.Data.Search.Indexing;
+using VirtoCommerce.SearchModule.Core.Model;
+using Xunit;
+
+namespace VirtoCommerce.InventoryModule.Tests;
+
+[Trait("Category", "Unit")]
+public class ProductAvailabilityDocumentBuilderTests
+{
+    /// <summary>
+    /// Integrators (VCST-5328 / VP-9216, Innovadis) need to subclass the availability
+    /// document builder and override <see cref="ProductAvailabilityDocumentBuilder.GetDocumentsAsync"/>
+    /// to customize the indexed availability documents. This derived class only compiles
+    /// when the base method is declared <c>virtual</c>; it is the red→green reproduction
+    /// for making the method overridable. The override does not call the base implementation,
+    /// so the injected search service is unused here.
+    /// </summary>
+    private sealed class TestableProductAvailabilityDocumentBuilder(IInventorySearchService inventorySearchService)
+        : ProductAvailabilityDocumentBuilder(inventorySearchService)
+    {
+        public bool OverrideInvoked { get; private set; }
+
+        public override Task<IList<IndexDocument>> GetDocumentsAsync(IList<string> documentIds)
+        {
+            OverrideInvoked = true;
+
+            IList<IndexDocument> documents = new List<IndexDocument>();
+            foreach (var documentId in documentIds)
+            {
+                documents.Add(new IndexDocument(documentId));
+            }
+
+            return Task.FromResult(documents);
+        }
+    }
+
+    [Fact]
+    public async Task GetDocumentsAsync_CanBeOverridden_InvokesDerivedImplementation()
+    {
+        // Arrange
+        var derived = new TestableProductAvailabilityDocumentBuilder(inventorySearchService: null);
+        // Reference through the base type to prove the override is dispatched virtually.
+        ProductAvailabilityDocumentBuilder builder = derived;
+        var documentIds = new List<string> { "product-1", "product-2" };
+
+        // Act
+        var documents = await builder.GetDocumentsAsync(documentIds);
+
+        // Assert — the derived implementation ran via virtual dispatch, not the base body.
+        Assert.True(derived.OverrideInvoked);
+        Assert.Equal(documentIds.Count, documents.Count);
+    }
+}


### PR DESCRIPTION
## Summary
Makes `ProductAvailabilityDocumentBuilder.GetDocumentsAsync` `virtual` so integrators can subclass the availability document builder and override how the `available_in` / `availability` / `inStock_quantity` index fields are produced. Fixes JIRA **VCST-5328** (mirrors **VP-9216**, Innovadis enhancement request).

## Root cause
`GetDocumentsAsync` was a non-virtual public method, so a derived builder could not override it (CS0506). All indexing logic lives inline in that single method, so an override is the only viable extension point.

## Fix
One-word change in `src/VirtoCommerce.InventoryModule.Data/Search/Indexing/ProductAvailabilityDocumentBuilder.cs`: `public async` → `public virtual async` on `GetDocumentsAsync`. The method signature, return type, and the `IIndexDocumentBuilder` interface contract are **unchanged** — this is purely additive and non-breaking. No behavioral change; `BuildSchemaAsync` is intentionally left as-is per the ticket scope.

## Test (red → green)
- Added `ProductAvailabilityDocumentBuilderTests.GetDocumentsAsync_CanBeOverridden_InvokesDerivedImplementation` in `tests/VirtoCommerce.InventoryModule.Tests`.
- It defines a derived `TestableProductAvailabilityDocumentBuilder` that **overrides** `GetDocumentsAsync` and asserts the override is invoked via base-typed virtual dispatch.
- **RED:** on `dev` the test file does not compile — `error CS0506: cannot override inherited member 'ProductAvailabilityDocumentBuilder.GetDocumentsAsync(...)' because it is not marked virtual, abstract, or override`.
- **GREEN:** with `virtual` added it compiles, the override is dispatched, and the test passes.

## Verification
- [x] `dotnet build -c Debug` — Build succeeded, 0 Warning(s), 0 Error(s)
- [x] `dotnet test` — Passed! Failed: 0, Passed: 19, Skipped: 0 (18 pre-existing + 1 new, all green; no existing test modified)
- [x] SonarCloud quality gate — **passed** (PR CI: `SonarCloud Code Analysis` ✅ + `SonarCloud` quality gate ✅; no new bug/vuln/hotspot on the changed lines)

## ⚠ Needs deploy verification
Statically verified only (compile + unit). There is no runtime behavior change to re-verify, but per pipeline policy the module must still build and deploy to QA before sign-off via the regression pipeline + `/qa-verify-fix VCST-5328`.

## Reviewer notes
- Minimal, single-repo, additive diff: one `virtual` modifier + one new test file.
- Reference: VCST-5328 / VP-9216 (Innovadis). Tag the original assignee for the enhancement context.

> 🤖 Opened by the QA auto-fix pipeline. **DO NOT MERGE until human review** + deploy verification. Not auto-merged.

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5328
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Inventory_3.1004.0-pr-162-4709.zip