### PR TITLE
VCST-5546: blade for products stock quantities

### DIFF
--- a/src/VirtoCommerce.InventoryModule.Core/Model/ProductInventoryInfo.cs
+++ b/src/VirtoCommerce.InventoryModule.Core/Model/ProductInventoryInfo.cs
@@ -1,0 +1,19 @@
+using VirtoCommerce.CatalogModule.Core.Model;
+
+namespace VirtoCommerce.InventoryModule.Core.Model
+{
+    /// <summary>
+    /// Inventory of a product along with the product information resolved from the catalog.
+    /// </summary>
+    public class ProductInventoryInfo
+    {
+        public string ProductId { get; set; }
+
+        /// <summary>
+        /// Null when the product no longer exists in the catalog.
+        /// </summary>
+        public CatalogProduct Product { get; set; }
+
+        public InventoryInfo Inventory { get; set; }
+    }
+}

--- a/src/VirtoCommerce.InventoryModule.Core/Model/Search/InventorySearchCriteria.cs
+++ b/src/VirtoCommerce.InventoryModule.Core/Model/Search/InventorySearchCriteria.cs
@@ -11,8 +11,8 @@ namespace VirtoCommerce.InventoryModule.Core.Model.Search
         public IList<string> ProductIds { get; set; }
 
         /// <summary>
-        /// Return only inventories with non-zero in stock quantity.
+        /// Return only inventories with positive in stock quantity.
         /// </summary>
-        public bool WithNonZeroQuantityOnly { get; set; }
+        public bool WithPositiveQuantityOnly { get; set; }
     }
 }

--- a/src/VirtoCommerce.InventoryModule.Core/Model/Search/InventorySearchCriteria.cs
+++ b/src/VirtoCommerce.InventoryModule.Core/Model/Search/InventorySearchCriteria.cs
@@ -9,5 +9,10 @@ namespace VirtoCommerce.InventoryModule.Core.Model.Search
         //public GeoPoint Location { get; set; }
         public IList<string> FulfillmentCenterIds { get; set; }
         public IList<string> ProductIds { get; set; }
+
+        /// <summary>
+        /// Return only inventories with non-zero in stock quantity.
+        /// </summary>
+        public bool WithNonZeroQuantityOnly { get; set; }
     }
 }

--- a/src/VirtoCommerce.InventoryModule.Core/Model/Search/ProductInventoryInfoSearchResult.cs
+++ b/src/VirtoCommerce.InventoryModule.Core/Model/Search/ProductInventoryInfoSearchResult.cs
@@ -1,0 +1,8 @@
+using VirtoCommerce.Platform.Core.Common;
+
+namespace VirtoCommerce.InventoryModule.Core.Model.Search
+{
+    public class ProductInventoryInfoSearchResult : GenericSearchResult<ProductInventoryInfo>
+    {
+    }
+}

--- a/src/VirtoCommerce.InventoryModule.Core/VirtoCommerce.InventoryModule.Core.csproj
+++ b/src/VirtoCommerce.InventoryModule.Core/VirtoCommerce.InventoryModule.Core.csproj
@@ -15,6 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     
+    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1029.0" />
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1007.0" />
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
     <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1004.0" />

--- a/src/VirtoCommerce.InventoryModule.Data/Handlers/ProductChangedEventHandler.cs
+++ b/src/VirtoCommerce.InventoryModule.Data/Handlers/ProductChangedEventHandler.cs
@@ -1,0 +1,43 @@
+using System.Linq;
+using System.Threading.Tasks;
+using VirtoCommerce.CatalogModule.Core.Events;
+using VirtoCommerce.InventoryModule.Core.Model.Search;
+using VirtoCommerce.InventoryModule.Core.Services;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Events;
+
+namespace VirtoCommerce.InventoryModule.Data.Handlers
+{
+    /// <summary>
+    /// Deletes inventories of the products deleted from the catalog, otherwise they stay forever
+    /// and are counted in every inventory search.
+    /// </summary>
+    public class ProductChangedEventHandler(
+        IInventorySearchService inventorySearchService,
+        IInventoryService inventoryService)
+        : IEventHandler<ProductChangedEvent>
+    {
+        public virtual async Task Handle(ProductChangedEvent message)
+        {
+            var deletedProductIds = message.ChangedEntries
+                .Where(x => x.EntryState == EntryState.Deleted && x.NewEntry != null)
+                .Select(x => x.NewEntry.Id)
+                .ToList();
+
+            if (deletedProductIds.Count == 0)
+            {
+                return;
+            }
+
+            var criteria = AbstractTypeFactory<InventorySearchCriteria>.TryCreateInstance();
+            criteria.ProductIds = deletedProductIds;
+
+            var inventories = await inventorySearchService.SearchAllNoCloneAsync(criteria);
+
+            if (inventories.Count > 0)
+            {
+                await inventoryService.DeleteAsync(inventories.Select(x => x.Id).ToList());
+            }
+        }
+    }
+}

--- a/src/VirtoCommerce.InventoryModule.Data/Services/InventorySearchService.cs
+++ b/src/VirtoCommerce.InventoryModule.Data/Services/InventorySearchService.cs
@@ -55,6 +55,11 @@ public class InventorySearchService(
             query = query.Where(x => criteria.FulfillmentCenterIds.Contains(x.FulfillmentCenterId));
         }
 
+        if (criteria.WithNonZeroQuantityOnly)
+        {
+            query = query.Where(x => x.InStockQuantity != 0);
+        }
+
         return query;
     }
 

--- a/src/VirtoCommerce.InventoryModule.Data/Services/InventorySearchService.cs
+++ b/src/VirtoCommerce.InventoryModule.Data/Services/InventorySearchService.cs
@@ -55,9 +55,9 @@ public class InventorySearchService(
             query = query.Where(x => criteria.FulfillmentCenterIds.Contains(x.FulfillmentCenterId));
         }
 
-        if (criteria.WithNonZeroQuantityOnly)
+        if (criteria.WithPositiveQuantityOnly)
         {
-            query = query.Where(x => x.InStockQuantity != 0);
+            query = query.Where(x => x.InStockQuantity > 0);
         }
 
         return query;

--- a/src/VirtoCommerce.InventoryModule.Web/Controllers/Api/InventoryModuleController.cs
+++ b/src/VirtoCommerce.InventoryModule.Web/Controllers/Api/InventoryModuleController.cs
@@ -345,7 +345,8 @@ namespace VirtoCommerce.InventoryModule.Web.Controllers.Api
 
             var productIds = inventories.Select(x => x.ProductId).Distinct().ToList();
             var responseGroup = (ItemResponseGroup.ItemInfo | ItemResponseGroup.ItemAssets).ToString();
-            var products = (await itemService.GetNoCloneAsync(productIds, responseGroup)).ToDictionary(x => x.Id);
+            // The products are cloned because the image URLs below are resolved in place and must not affect the cache
+            var products = (await itemService.GetAsync(productIds, responseGroup)).ToDictionary(x => x.Id);
 
             return inventories.Select(inventory =>
             {

--- a/src/VirtoCommerce.InventoryModule.Web/Controllers/Api/InventoryModuleController.cs
+++ b/src/VirtoCommerce.InventoryModule.Web/Controllers/Api/InventoryModuleController.cs
@@ -1,9 +1,14 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc;
+using VirtoCommerce.AssetsModule.Core.Assets;
+using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.CatalogModule.Core.Services;
 using VirtoCommerce.InventoryModule.Core.Model;
 using VirtoCommerce.InventoryModule.Core.Model.Search;
 using VirtoCommerce.InventoryModule.Core.Services;
@@ -19,7 +24,9 @@ namespace VirtoCommerce.InventoryModule.Web.Controllers.Api
         IInventorySearchService inventorySearchService,
         IProductInventorySearchService productInventorySearchService,
         IFulfillmentCenterSearchService fulfillmentCenterSearchService,
-        IFulfillmentCenterService fulfillmentCenterService)
+        IFulfillmentCenterService fulfillmentCenterService,
+        IItemService itemService,
+        IBlobUrlResolver blobUrlResolver)
         : Controller
     {
         /// <summary>
@@ -43,6 +50,27 @@ namespace VirtoCommerce.InventoryModule.Web.Controllers.Api
         public async Task<ActionResult<InventoryInfoSearchResult>> SearchInventories([FromBody] InventorySearchCriteria searchCriteria)
         {
             var result = await inventorySearchService.SearchNoCloneAsync(searchCriteria);
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Search inventories by given criteria and return them along with the product information
+        /// </summary>
+        /// <remarks>
+        /// Products are resolved from the catalog on the server, so the caller does not need catalog permissions.
+        /// Inventories of the products missing in the catalog are returned with the empty product.
+        /// </remarks>
+        [HttpPost]
+        [Route("inventory/products/search")]
+        [Authorize(Permissions.Read)]
+        public async Task<ActionResult<ProductInventoryInfoSearchResult>> SearchProductInventoryInfos([FromBody] InventorySearchCriteria searchCriteria)
+        {
+            var searchResult = await inventorySearchService.SearchNoCloneAsync(searchCriteria);
+
+            var result = AbstractTypeFactory<ProductInventoryInfoSearchResult>.TryCreateInstance();
+            result.TotalCount = searchResult.TotalCount;
+            result.Results = await GetProductInventoryInfos(searchResult.Results);
+
             return Ok(result);
         }
 
@@ -306,6 +334,34 @@ namespace VirtoCommerce.InventoryModule.Web.Controllers.Api
             await inventoryService.SaveChangesAsync([inventory]);
 
             return NoContent();
+        }
+
+        private async Task<IList<ProductInventoryInfo>> GetProductInventoryInfos(IList<InventoryInfo> inventories)
+        {
+            if (inventories.Count == 0)
+            {
+                return [];
+            }
+
+            var productIds = inventories.Select(x => x.ProductId).Distinct().ToList();
+            var responseGroup = (ItemResponseGroup.ItemInfo | ItemResponseGroup.ItemAssets).ToString();
+            var products = (await itemService.GetNoCloneAsync(productIds, responseGroup)).ToDictionary(x => x.Id);
+
+            return inventories.Select(inventory =>
+            {
+                var result = AbstractTypeFactory<ProductInventoryInfo>.TryCreateInstance();
+                result.ProductId = inventory.ProductId;
+                result.Inventory = inventory;
+                result.Product = products.GetValueSafe(inventory.ProductId);
+
+                foreach (var image in result.Product?.Images ?? [])
+                {
+                    image.RelativeUrl = image.Url;
+                    image.Url = blobUrlResolver.GetAbsoluteUrl(image.Url);
+                }
+
+                return result;
+            }).ToList();
         }
     }
 }

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/de.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/de.VirtoCommerce.Inventory.json
@@ -23,11 +23,15 @@
         }
       },
       "fulfillment-center-products-list": {
+        "select-products-title": "Produkte auswählen",
         "labels": {
+          "picture": "Bild",
           "product-name": "Produkt",
           "product-code": "SKU",
           "in-stock-quantity": "Menge auf Lager",
-          "reserved-quantity": "Reservierte Menge"
+          "reserved-quantity": "Reservierte Menge",
+          "in-stock-only": "Nur auf Lager",
+          "no-product": "Es gibt kein Produkt mit dieser ID"
         }
       },
       "fulfillment-center-detail": {

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/de.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/de.VirtoCommerce.Inventory.json
@@ -22,6 +22,14 @@
           "in-stock-quantity": "Menge auf Lager"
         }
       },
+      "fulfillment-center-products-list": {
+        "labels": {
+          "product-name": "Produkt",
+          "product-code": "SKU",
+          "in-stock-quantity": "Menge auf Lager",
+          "reserved-quantity": "Reservierte Menge"
+        }
+      },
       "fulfillment-center-detail": {
         "subtitle": "Erfüllungszentrum bearbeiten",
         "labels": {
@@ -60,6 +68,10 @@
       "inventoryWidget": {
         "title": "Bestand",
         "blade-subtitle": "Wählen Sie ein Erfüllungszentrum für die Bestandsverwaltung"
+      },
+      "fulfillmentCenterProductsWidget": {
+        "title": "Produkte",
+        "blade-subtitle": "Produkte auf Lager in diesem Erfüllungszentrum"
       },
       "fulfillmentWidget": {
         "title": "Erfüllungszentren",

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/en.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/en.VirtoCommerce.Inventory.json
@@ -23,11 +23,15 @@
         }
       },
       "fulfillment-center-products-list": {
+        "select-products-title": "Select products",
         "labels": {
+          "picture": "Image",
           "product-name": "Product",
           "product-code": "SKU",
           "in-stock-quantity": "In stock quantity",
-          "reserved-quantity": "Reserved quantity"
+          "reserved-quantity": "Reserved quantity",
+          "in-stock-only": "In stock only",
+          "no-product": "There is no product item with this ID"
         }
       },
       "fulfillment-center-detail": {

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/en.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/en.VirtoCommerce.Inventory.json
@@ -22,6 +22,14 @@
           "in-stock-quantity": "In stock quantity"
         }
       },
+      "fulfillment-center-products-list": {
+        "labels": {
+          "product-name": "Product",
+          "product-code": "SKU",
+          "in-stock-quantity": "In stock quantity",
+          "reserved-quantity": "Reserved quantity"
+        }
+      },
       "fulfillment-center-detail": {
         "subtitle": "Editing fulfillment center",
         "labels": {
@@ -60,6 +68,10 @@
       "inventoryWidget": {
         "title": "Inventory",
         "blade-subtitle": "Select a fulfillment center for inventory management"
+      },
+      "fulfillmentCenterProductsWidget": {
+        "title": "Products",
+        "blade-subtitle": "Products in stock in this fulfillment center"
       },
       "fulfillmentWidget": {
         "title": "Fulfillment centers",

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/es.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/es.VirtoCommerce.Inventory.json
@@ -23,11 +23,15 @@
         }
       },
       "fulfillment-center-products-list": {
+        "select-products-title": "Seleccionar productos",
         "labels": {
+          "picture": "Imagen",
           "product-name": "Producto",
           "product-code": "SKU",
           "in-stock-quantity": "Cantidad en stock",
-          "reserved-quantity": "Cantidad reservada"
+          "reserved-quantity": "Cantidad reservada",
+          "in-stock-only": "Solo en stock",
+          "no-product": "No hay un producto con este ID"
         }
       },
       "fulfillment-center-detail": {

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/es.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/es.VirtoCommerce.Inventory.json
@@ -22,6 +22,14 @@
           "in-stock-quantity": "Cantidad en stock"
         }
       },
+      "fulfillment-center-products-list": {
+        "labels": {
+          "product-name": "Producto",
+          "product-code": "SKU",
+          "in-stock-quantity": "Cantidad en stock",
+          "reserved-quantity": "Cantidad reservada"
+        }
+      },
       "fulfillment-center-detail": {
         "subtitle": "Editando centro de cumplimiento",
         "labels": {
@@ -60,6 +68,10 @@
       "inventoryWidget": {
         "title": "Inventario",
         "blade-subtitle": "Seleccione un centro de cumplimiento para la gestión del inventario"
+      },
+      "fulfillmentCenterProductsWidget": {
+        "title": "Productos",
+        "blade-subtitle": "Productos en stock en este centro de cumplimiento"
       },
       "fulfillmentWidget": {
         "title": "Centros de cumplimiento",

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/fi.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/fi.VirtoCommerce.Inventory.json
@@ -23,11 +23,15 @@
         }
       },
       "fulfillment-center-products-list": {
+        "select-products-title": "Valitse tuotteet",
         "labels": {
+          "picture": "Kuva",
           "product-name": "Tuote",
           "product-code": "SKU",
           "in-stock-quantity": "Varastossa oleva määrä",
-          "reserved-quantity": "Varattu määrä"
+          "reserved-quantity": "Varattu määrä",
+          "in-stock-only": "Vain varastossa",
+          "no-product": "Tällä tunnuksella ei ole tuotetta"
         }
       },
       "fulfillment-center-detail": {

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/fi.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/fi.VirtoCommerce.Inventory.json
@@ -22,6 +22,14 @@
           "in-stock-quantity": "Varastossa oleva määrä"
         }
       },
+      "fulfillment-center-products-list": {
+        "labels": {
+          "product-name": "Tuote",
+          "product-code": "SKU",
+          "in-stock-quantity": "Varastossa oleva määrä",
+          "reserved-quantity": "Varattu määrä"
+        }
+      },
       "fulfillment-center-detail": {
         "subtitle": "Muokkaa jakelukeskusta",
         "labels": {
@@ -60,6 +68,10 @@
       "inventoryWidget": {
         "title": "Varasto",
         "blade-subtitle": "Valitse jakelukeskus varastonhallintaan"
+      },
+      "fulfillmentCenterProductsWidget": {
+        "title": "Tuotteet",
+        "blade-subtitle": "Tässä jakelukeskuksessa varastossa olevat tuotteet"
       },
       "fulfillmentWidget": {
         "title": "Jakelukeskukset",

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/fr.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/fr.VirtoCommerce.Inventory.json
@@ -23,11 +23,15 @@
         }
       },
       "fulfillment-center-products-list": {
+        "select-products-title": "Sélectionner des produits",
         "labels": {
+          "picture": "Image",
           "product-name": "Produit",
           "product-code": "SKU",
           "in-stock-quantity": "Quantité en stock",
-          "reserved-quantity": "Quantité réservée"
+          "reserved-quantity": "Quantité réservée",
+          "in-stock-only": "En stock uniquement",
+          "no-product": "Aucun produit avec cet ID"
         }
       },
       "fulfillment-center-detail": {

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/fr.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/fr.VirtoCommerce.Inventory.json
@@ -22,6 +22,14 @@
           "in-stock-quantity": "Quantité en stock"
         }
       },
+      "fulfillment-center-products-list": {
+        "labels": {
+          "product-name": "Produit",
+          "product-code": "SKU",
+          "in-stock-quantity": "Quantité en stock",
+          "reserved-quantity": "Quantité réservée"
+        }
+      },
       "fulfillment-center-detail": {
         "subtitle": "Édition du centre de traitement des commandes",
         "labels": {
@@ -60,6 +68,10 @@
       "inventoryWidget": {
         "title": "Inventaire",
         "blade-subtitle": "Sélectionnez un centre de traitement des commandes pour la gestion de l'inventaire"
+      },
+      "fulfillmentCenterProductsWidget": {
+        "title": "Produits",
+        "blade-subtitle": "Produits en stock dans ce centre de traitement des commandes"
       },
       "fulfillmentWidget": {
         "title": "Centres de traitement",

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/it.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/it.VirtoCommerce.Inventory.json
@@ -23,11 +23,15 @@
         }
       },
       "fulfillment-center-products-list": {
+        "select-products-title": "Seleziona prodotti",
         "labels": {
+          "picture": "Immagine",
           "product-name": "Prodotto",
           "product-code": "SKU",
           "in-stock-quantity": "Quantità disponibile",
-          "reserved-quantity": "Quantità riservata"
+          "reserved-quantity": "Quantità riservata",
+          "in-stock-only": "Solo disponibili",
+          "no-product": "Non esiste un prodotto con questo ID"
         }
       },
       "fulfillment-center-detail": {

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/it.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/it.VirtoCommerce.Inventory.json
@@ -22,6 +22,14 @@
           "in-stock-quantity": "Quantità disponibile"
         }
       },
+      "fulfillment-center-products-list": {
+        "labels": {
+          "product-name": "Prodotto",
+          "product-code": "SKU",
+          "in-stock-quantity": "Quantità disponibile",
+          "reserved-quantity": "Quantità riservata"
+        }
+      },
       "fulfillment-center-detail": {
         "subtitle": "Modifica centro di approvvigionamento",
         "labels": {
@@ -60,6 +68,10 @@
       "inventoryWidget": {
         "title": "Inventario",
         "blade-subtitle": "Seleziona un centro di approvvigionamento per la gestione dell'inventario"
+      },
+      "fulfillmentCenterProductsWidget": {
+        "title": "Prodotti",
+        "blade-subtitle": "Prodotti disponibili in questo centro di approvvigionamento"
       },
       "fulfillmentWidget": {
         "title": "Centri di evasione",

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/ja.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/ja.VirtoCommerce.Inventory.json
@@ -23,11 +23,15 @@
         }
       },
       "fulfillment-center-products-list": {
+        "select-products-title": "商品を選択",
         "labels": {
+          "picture": "画像",
           "product-name": "商品",
           "product-code": "SKU",
           "in-stock-quantity": "在庫数量",
-          "reserved-quantity": "予約済み数量"
+          "reserved-quantity": "予約済み数量",
+          "in-stock-only": "在庫ありのみ",
+          "no-product": "このIDの製品は存在しません"
         }
       },
       "fulfillment-center-detail": {

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/ja.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/ja.VirtoCommerce.Inventory.json
@@ -22,6 +22,14 @@
           "in-stock-quantity": "在庫数量"
         }
       },
+      "fulfillment-center-products-list": {
+        "labels": {
+          "product-name": "商品",
+          "product-code": "SKU",
+          "in-stock-quantity": "在庫数量",
+          "reserved-quantity": "予約済み数量"
+        }
+      },
       "fulfillment-center-detail": {
         "subtitle": "フルフィルメントセンターの編集",
         "labels": {
@@ -60,6 +68,10 @@
       "inventoryWidget": {
         "title": "在庫",
         "blade-subtitle": "在庫管理のためにフルフィルメントセンターを選択してください"
+      },
+      "fulfillmentCenterProductsWidget": {
+        "title": "商品",
+        "blade-subtitle": "このフルフィルメントセンターの在庫商品"
       },
       "fulfillmentWidget": {
         "title": "フルフィルメントセンター",

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/no.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/no.VirtoCommerce.Inventory.json
@@ -22,6 +22,14 @@
           "in-stock-quantity": "Antall på lager"
         }
       },
+      "fulfillment-center-products-list": {
+        "labels": {
+          "product-name": "Produkt",
+          "product-code": "SKU",
+          "in-stock-quantity": "Antall på lager",
+          "reserved-quantity": "Reservert antall"
+        }
+      },
       "fulfillment-center-detail": {
         "subtitle": "Rediger oppfyllelsessenter",
         "labels": {
@@ -60,6 +68,10 @@
       "inventoryWidget": {
         "title": "Lager",
         "blade-subtitle": "Velg et oppfyllelsessenter for lageradministrasjon"
+      },
+      "fulfillmentCenterProductsWidget": {
+        "title": "Produkter",
+        "blade-subtitle": "Produkter på lager i dette oppfyllelsessenteret"
       },
       "fulfillmentWidget": {
         "title": "Oppfyllelsessentre",

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/no.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/no.VirtoCommerce.Inventory.json
@@ -23,11 +23,15 @@
         }
       },
       "fulfillment-center-products-list": {
+        "select-products-title": "Velg produkter",
         "labels": {
+          "picture": "Bilde",
           "product-name": "Produkt",
           "product-code": "SKU",
           "in-stock-quantity": "Antall på lager",
-          "reserved-quantity": "Reservert antall"
+          "reserved-quantity": "Reservert antall",
+          "in-stock-only": "Kun på lager",
+          "no-product": "Det finnes ingen produkter med denne ID-en"
         }
       },
       "fulfillment-center-detail": {

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/pl.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/pl.VirtoCommerce.Inventory.json
@@ -22,6 +22,14 @@
           "in-stock-quantity": "Ilość dostępna"
         }
       },
+      "fulfillment-center-products-list": {
+        "labels": {
+          "product-name": "Produkt",
+          "product-code": "SKU",
+          "in-stock-quantity": "Ilość dostępna",
+          "reserved-quantity": "Ilość zarezerwowana"
+        }
+      },
       "fulfillment-center-detail": {
         "subtitle": "Edycja centrum realizacji",
         "labels": {
@@ -60,6 +68,10 @@
       "inventoryWidget": {
         "title": "Stan magazynowy",
         "blade-subtitle": "Wybierz centrum realizacji do zarządzania stanem magazynowym"
+      },
+      "fulfillmentCenterProductsWidget": {
+        "title": "Produkty",
+        "blade-subtitle": "Produkty dostępne w tym centrum realizacji"
       },
       "fulfillmentWidget": {
         "title": "Centra realizacji",

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/pl.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/pl.VirtoCommerce.Inventory.json
@@ -23,11 +23,15 @@
         }
       },
       "fulfillment-center-products-list": {
+        "select-products-title": "Wybierz produkty",
         "labels": {
+          "picture": "Obrazek",
           "product-name": "Produkt",
           "product-code": "SKU",
           "in-stock-quantity": "Ilość dostępna",
-          "reserved-quantity": "Ilość zarezerwowana"
+          "reserved-quantity": "Ilość zarezerwowana",
+          "in-stock-only": "Tylko dostępne",
+          "no-product": "Nie ma produktu o tym ID"
         }
       },
       "fulfillment-center-detail": {

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/pt.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/pt.VirtoCommerce.Inventory.json
@@ -22,6 +22,14 @@
           "in-stock-quantity": "Quantidade em estoque"
         }
       },
+      "fulfillment-center-products-list": {
+        "labels": {
+          "product-name": "Produto",
+          "product-code": "SKU",
+          "in-stock-quantity": "Quantidade em estoque",
+          "reserved-quantity": "Quantidade reservada"
+        }
+      },
       "fulfillment-center-detail": {
         "subtitle": "Edição do centro de atendimento",
         "labels": {
@@ -60,6 +68,10 @@
       "inventoryWidget": {
         "title": "Inventário",
         "blade-subtitle": "Selecione um centro de atendimento para gerenciamento de inventário"
+      },
+      "fulfillmentCenterProductsWidget": {
+        "title": "Produtos",
+        "blade-subtitle": "Produtos em estoque neste centro de atendimento"
       },
       "fulfillmentWidget": {
         "title": "Centros de atendimento",

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/pt.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/pt.VirtoCommerce.Inventory.json
@@ -23,11 +23,15 @@
         }
       },
       "fulfillment-center-products-list": {
+        "select-products-title": "Selecionar produtos",
         "labels": {
+          "picture": "Imagem",
           "product-name": "Produto",
           "product-code": "SKU",
           "in-stock-quantity": "Quantidade em estoque",
-          "reserved-quantity": "Quantidade reservada"
+          "reserved-quantity": "Quantidade reservada",
+          "in-stock-only": "Apenas em estoque",
+          "no-product": "Não há produto com este ID"
         }
       },
       "fulfillment-center-detail": {

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/ru.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/ru.VirtoCommerce.Inventory.json
@@ -22,6 +22,14 @@
           "in-stock-quantity": "Количество в наличии"
         }
       },
+      "fulfillment-center-products-list": {
+        "labels": {
+          "product-name": "Товар",
+          "product-code": "SKU",
+          "in-stock-quantity": "Количество в наличии",
+          "reserved-quantity": "Зарезервированное количество"
+        }
+      },
       "fulfillment-center-detail": {
         "subtitle": "Редактирование центра выполнения заказов",
         "labels": {
@@ -60,6 +68,10 @@
       "inventoryWidget": {
         "title": "Складские запасы",
         "blade-subtitle": "Выберите центр выполнения заказов для управления складскими запасами"
+      },
+      "fulfillmentCenterProductsWidget": {
+        "title": "Товары",
+        "blade-subtitle": "Товары в наличии в этом центре выполнения заказов"
       },
       "fulfillmentWidget": {
         "title": "Центры выполнения заказов",

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/ru.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/ru.VirtoCommerce.Inventory.json
@@ -23,11 +23,15 @@
         }
       },
       "fulfillment-center-products-list": {
+        "select-products-title": "Выберите товары",
         "labels": {
+          "picture": "Изображение",
           "product-name": "Товар",
           "product-code": "SKU",
           "in-stock-quantity": "Количество в наличии",
-          "reserved-quantity": "Зарезервированное количество"
+          "reserved-quantity": "Зарезервированное количество",
+          "in-stock-only": "Только в наличии",
+          "no-product": "Товар с таким ID не существует"
         }
       },
       "fulfillment-center-detail": {

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/sv.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/sv.VirtoCommerce.Inventory.json
@@ -22,6 +22,14 @@
           "in-stock-quantity": "Lagerkvantitet"
         }
       },
+      "fulfillment-center-products-list": {
+        "labels": {
+          "product-name": "Produkt",
+          "product-code": "SKU",
+          "in-stock-quantity": "Lagerkvantitet",
+          "reserved-quantity": "Reserverad kvantitet"
+        }
+      },
       "fulfillment-center-detail": {
         "subtitle": "Redigera distributionscenter",
         "labels": {
@@ -60,6 +68,10 @@
       "inventoryWidget": {
         "title": "Lager",
         "blade-subtitle": "Välj ett distributionscenter för lagerhantering"
+      },
+      "fulfillmentCenterProductsWidget": {
+        "title": "Produkter",
+        "blade-subtitle": "Produkter i lager på detta distributionscenter"
       },
       "fulfillmentWidget": {
         "title": "Distributionscenter",

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/sv.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/sv.VirtoCommerce.Inventory.json
@@ -23,11 +23,15 @@
         }
       },
       "fulfillment-center-products-list": {
+        "select-products-title": "Välj produkter",
         "labels": {
+          "picture": "Bild",
           "product-name": "Produkt",
           "product-code": "SKU",
           "in-stock-quantity": "Lagerkvantitet",
-          "reserved-quantity": "Reserverad kvantitet"
+          "reserved-quantity": "Reserverad kvantitet",
+          "in-stock-only": "Endast i lager",
+          "no-product": "Det finns ingen produkt med detta ID"
         }
       },
       "fulfillment-center-detail": {

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/zh.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/zh.VirtoCommerce.Inventory.json
@@ -23,11 +23,15 @@
         }
       },
       "fulfillment-center-products-list": {
+        "select-products-title": "选择商品",
         "labels": {
+          "picture": "图片",
           "product-name": "商品",
           "product-code": "SKU",
           "in-stock-quantity": "库存数量",
-          "reserved-quantity": "已预留数量"
+          "reserved-quantity": "已预留数量",
+          "in-stock-only": "仅有库存",
+          "no-product": "没有此ID的产品项"
         }
       },
       "fulfillment-center-detail": {

--- a/src/VirtoCommerce.InventoryModule.Web/Localizations/zh.VirtoCommerce.Inventory.json
+++ b/src/VirtoCommerce.InventoryModule.Web/Localizations/zh.VirtoCommerce.Inventory.json
@@ -22,6 +22,14 @@
           "in-stock-quantity": "库存数量"
         }
       },
+      "fulfillment-center-products-list": {
+        "labels": {
+          "product-name": "商品",
+          "product-code": "SKU",
+          "in-stock-quantity": "库存数量",
+          "reserved-quantity": "已预留数量"
+        }
+      },
       "fulfillment-center-detail": {
         "subtitle": "编辑履行中心",
         "labels": {
@@ -60,6 +68,10 @@
       "inventoryWidget": {
         "title": "库存",
         "blade-subtitle": "选择一个履行中心进行库存管理"
+      },
+      "fulfillmentCenterProductsWidget": {
+        "title": "商品",
+        "blade-subtitle": "此履行中心的库存商品"
       },
       "fulfillmentWidget": {
         "title": "履行中心",

--- a/src/VirtoCommerce.InventoryModule.Web/Module.cs
+++ b/src/VirtoCommerce.InventoryModule.Web/Module.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using VirtoCommerce.CatalogModule.Core.Events;
 using VirtoCommerce.InventoryModule.Core;
 using VirtoCommerce.InventoryModule.Core.Events;
 using VirtoCommerce.InventoryModule.Core.Model;
@@ -78,6 +79,7 @@ namespace VirtoCommerce.InventoryModule.Web
             serviceCollection.AddTransient<LogChangesChangedEventHandler>();
             serviceCollection.AddTransient<IndexInventoryChangedEventHandler>();
             serviceCollection.AddTransient<FulfillmentCenterChangedEventHandler>();
+            serviceCollection.AddTransient<ProductChangedEventHandler>();
         }
 
         public void PostInitialize(IApplicationBuilder appBuilder)
@@ -129,6 +131,7 @@ namespace VirtoCommerce.InventoryModule.Web
             appBuilder.RegisterEventHandler<InventoryChangedEvent, LogChangesChangedEventHandler>();
             appBuilder.RegisterEventHandler<InventoryChangedEvent, IndexInventoryChangedEventHandler>();
             appBuilder.RegisterEventHandler<FulfillmentCenterChangedEvent, FulfillmentCenterChangedEventHandler>();
+            appBuilder.RegisterEventHandler<ProductChangedEvent, ProductChangedEventHandler>();
         }
 
         public void Uninstall()

--- a/src/VirtoCommerce.InventoryModule.Web/Scripts/blades/fulfillment-center-products-list.js
+++ b/src/VirtoCommerce.InventoryModule.Web/Scripts/blades/fulfillment-center-products-list.js
@@ -2,63 +2,177 @@ angular.module('virtoCommerce.inventoryModule')
     .controller('virtoCommerce.inventoryModule.fulfillmentCenterProductsListController',
         [
             '$scope',
+            '$translate',
             'platformWebApp.bladeUtils',
             'platformWebApp.uiGridHelper',
             'platformWebApp.bladeNavigationService',
+            'platformWebApp.authService',
             'uiGridConstants',
             'virtoCommerce.inventoryModule.inventories',
-            'virtoCommerce.catalogModule.items',
-            function ($scope, bladeUtils, uiGridHelper, bladeNavigationService, uiGridConstants, inventories, items) {
+            function ($scope, $translate, bladeUtils, uiGridHelper, bladeNavigationService, authService, uiGridConstants, inventories) {
                 $scope.uiGridConstants = uiGridConstants;
+                $scope.noProductName = $translate.instant('inventory.blades.fulfillment-center-products-list.labels.no-product');
+
                 var blade = $scope.blade;
                 blade.headIcon = 'fas fa-boxes';
+                blade.updatePermission = 'inventory:update';
+
+                var filter = $scope.filter = { inStockOnly: true };
+
+                filter.criteriaChanged = function () {
+                    if ($scope.pageSettings.currentPage > 1) {
+                        $scope.pageSettings.currentPage = 1;
+                    } else {
+                        blade.refresh();
+                    }
+                };
 
                 blade.refresh = function () {
                     blade.isLoading = true;
 
-                    inventories.search({
-                        fulfillmentCenterIds: [blade.currentEntityId],
-                        withNonZeroQuantityOnly: true,
-                        sort: uiGridHelper.getSortExpression($scope),
-                        skip: ($scope.pageSettings.currentPage - 1) * $scope.pageSettings.itemsPerPageCount,
-                        take: $scope.pageSettings.itemsPerPageCount
-                    }, function (data) {
+                    inventories.searchProducts(getSearchCriteria(), function (data) {
                         $scope.pageSettings.totalItems = data.totalCount;
-                        fillProductInfo(data.results);
+                        blade.currentEntities = _.each(data.results, fillMissingProduct);
+                        blade.isLoading = false;
+
+                        if (blade.parentWidgetRefresh) {
+                            blade.parentWidgetRefresh();
+                        }
                     }, function (error) {
                         blade.isLoading = false;
                         bladeNavigationService.setError('Error ' + error.status, blade);
                     });
                 };
 
-                // Inventory records store the product ID only, so name and code are resolved from the catalog.
-                // Records whose product no longer exists in the catalog are skipped, therefore a page may
-                // contain fewer rows than the page size and the total count may include such orphans.
-                function fillProductInfo(inventoryList) {
-                    var productIds = _.uniq(_.pluck(inventoryList, 'productId'));
+                function getSearchCriteria() {
+                    return {
+                        fulfillmentCenterIds: [blade.currentEntityId],
+                        withPositiveQuantityOnly: filter.inStockOnly,
+                        // the grid sends no sort expression until the user clicks a column header
+                        sort: uiGridHelper.getSortExpression($scope) || 'inStockQuantity:desc',
+                        skip: ($scope.pageSettings.currentPage - 1) * $scope.pageSettings.itemsPerPageCount,
+                        take: $scope.pageSettings.itemsPerPageCount
+                    };
+                }
 
-                    if (!_.any(productIds)) {
-                        blade.currentEntities = [];
-                        blade.isLoading = false;
-                        return;
-                    }
+                // Inventory records store the product ID only, the product itself is resolved by the API.
+                // It is missing when the product has been deleted from the catalog.
+                function fillMissingProduct(productInventory) {
+                    productInventory.product = productInventory.product || { name: $scope.noProductName };
+                }
 
-                    items.plenty({ respGroup: 'ItemInfo' }, productIds, function (products) {
-                        var productsById = _.indexBy(products, 'id');
+                $scope.selectNode = function (productInventory) {
+                    $scope.selectedNodeId = productInventory.productId;
 
-                        blade.currentEntities = _.filter(inventoryList, function (inventory) {
-                            var product = productsById[inventory.productId];
-                            if (product) {
-                                inventory.productName = product.name;
-                                inventory.productCode = product.code;
+                    var newBlade = {
+                        id: 'fulfillmentCenterInventoryDetail',
+                        itemId: productInventory.productId,
+                        data: productInventory.inventory,
+                        getEntity: function () {
+                            return getInventory(productInventory);
+                        },
+                        title: productInventory.product.name,
+                        subtitle: 'inventory.blades.inventory-detail.subtitle',
+                        controller: 'virtoCommerce.inventoryModule.inventoryDetailController',
+                        template: 'Modules/$(VirtoCommerce.Inventory)/Scripts/blades/inventory-detail.tpl.html'
+                    };
+                    bladeNavigationService.showBlade(newBlade, blade);
+                };
+
+                function getInventory(productInventory) {
+                    blade.refresh();
+
+                    return inventories.searchProducts({
+                        fulfillmentCenterIds: [blade.currentEntityId],
+                        productIds: [productInventory.productId],
+                        take: 1
+                    }).$promise.then(function (data) {
+                        var actual = _.first(data.results);
+                        return actual ? actual.inventory : productInventory.inventory;
+                    });
+                }
+
+                function openAddProductsBlade() {
+                    $scope.selectedNodeId = null;
+                    var selectedProducts = [];
+
+                    var newBlade = {
+                        id: 'CatalogItemsSelect',
+                        title: 'inventory.blades.fulfillment-center-products-list.select-products-title',
+                        controller: 'virtoCommerce.catalogModule.catalogItemSelectController',
+                        template: 'Modules/$(VirtoCommerce.Catalog)/Scripts/blades/common/catalog-items-select.tpl.html',
+                        breadcrumbs: [],
+                        toolbarCommands: [
+                            {
+                                name: "platform.commands.add", icon: 'fas fa-plus',
+                                executeMethod: function (selectBlade) {
+                                    addProducts(selectedProducts, selectBlade);
+                                },
+                                canExecuteMethod: function () {
+                                    return selectedProducts.length > 0;
+                                }
                             }
-                            return product;
-                        });
+                        ]
+                    };
 
-                        blade.isLoading = false;
+                    newBlade.options = {
+                        checkItemFn: function (listItem, isSelected) {
+                            if (listItem.type === 'category') {
+                                newBlade.error = 'Categories are not supported';
+                                listItem.selected = undefined;
+                            } else {
+                                if (isSelected) {
+                                    if (_.all(selectedProducts, function (x) { return x.id !== listItem.id; })) {
+                                        selectedProducts.push(listItem);
+                                    }
+                                } else {
+                                    selectedProducts = _.reject(selectedProducts, function (x) { return x.id === listItem.id; });
+                                }
+                                newBlade.error = undefined;
+                            }
+                        }
+                    };
+
+                    bladeNavigationService.showBlade(newBlade, blade);
+                }
+
+                function addProducts(products, selectBlade) {
+                    selectBlade.isLoading = true;
+                    var productIds = _.pluck(products, 'id');
+
+                    inventories.searchProducts({
+                        fulfillmentCenterIds: [blade.currentEntityId],
+                        productIds: productIds,
+                        take: productIds.length
+                    }, function (data) {
+                        var newInventories = _.chain(productIds)
+                            .difference(_.pluck(data.results, 'productId'))
+                            .map(function (productId) {
+                                return {
+                                    productId: productId,
+                                    fulfillmentCenterId: blade.currentEntityId,
+                                    inStockQuantity: 0
+                                };
+                            })
+                            .value();
+
+                        if (!newInventories.length) {
+                            bladeNavigationService.closeBlade(selectBlade);
+                            return;
+                        }
+
+                        inventories.upsert(newInventories, function () {
+                            bladeNavigationService.closeBlade(selectBlade);
+                            // the added products have no stock yet, so they are hidden by the default filter
+                            filter.inStockOnly = false;
+                            filter.criteriaChanged();
+                        }, function (error) {
+                            selectBlade.isLoading = false;
+                            bladeNavigationService.setError('Error ' + error.status, selectBlade);
+                        });
                     }, function (error) {
-                        blade.isLoading = false;
-                        bladeNavigationService.setError('Error ' + error.status, blade);
+                        selectBlade.isLoading = false;
+                        bladeNavigationService.setError('Error ' + error.status, selectBlade);
                     });
                 }
 
@@ -69,6 +183,15 @@ angular.module('virtoCommerce.inventoryModule')
                         canExecuteMethod: function () {
                             return true;
                         }
+                    },
+                    {
+                        name: "platform.commands.add", icon: 'fas fa-plus',
+                        executeMethod: openAddProductsBlade,
+                        canExecuteMethod: function () {
+                            // products are selected from the catalog
+                            return authService.checkPermission('catalog:read');
+                        },
+                        permission: blade.updatePermission
                     }
                 ];
 

--- a/src/VirtoCommerce.InventoryModule.Web/Scripts/blades/fulfillment-center-products-list.js
+++ b/src/VirtoCommerce.InventoryModule.Web/Scripts/blades/fulfillment-center-products-list.js
@@ -1,0 +1,82 @@
+angular.module('virtoCommerce.inventoryModule')
+    .controller('virtoCommerce.inventoryModule.fulfillmentCenterProductsListController',
+        [
+            '$scope',
+            'platformWebApp.bladeUtils',
+            'platformWebApp.uiGridHelper',
+            'platformWebApp.bladeNavigationService',
+            'uiGridConstants',
+            'virtoCommerce.inventoryModule.inventories',
+            'virtoCommerce.catalogModule.items',
+            function ($scope, bladeUtils, uiGridHelper, bladeNavigationService, uiGridConstants, inventories, items) {
+                $scope.uiGridConstants = uiGridConstants;
+                var blade = $scope.blade;
+                blade.headIcon = 'fas fa-boxes';
+
+                blade.refresh = function () {
+                    blade.isLoading = true;
+
+                    inventories.search({
+                        fulfillmentCenterIds: [blade.currentEntityId],
+                        withNonZeroQuantityOnly: true,
+                        sort: uiGridHelper.getSortExpression($scope),
+                        skip: ($scope.pageSettings.currentPage - 1) * $scope.pageSettings.itemsPerPageCount,
+                        take: $scope.pageSettings.itemsPerPageCount
+                    }, function (data) {
+                        $scope.pageSettings.totalItems = data.totalCount;
+                        fillProductInfo(data.results);
+                    }, function (error) {
+                        blade.isLoading = false;
+                        bladeNavigationService.setError('Error ' + error.status, blade);
+                    });
+                };
+
+                // Inventory records store the product ID only, so name and code are resolved from the catalog.
+                // Records whose product no longer exists in the catalog are skipped, therefore a page may
+                // contain fewer rows than the page size and the total count may include such orphans.
+                function fillProductInfo(inventoryList) {
+                    var productIds = _.uniq(_.pluck(inventoryList, 'productId'));
+
+                    if (!_.any(productIds)) {
+                        blade.currentEntities = [];
+                        blade.isLoading = false;
+                        return;
+                    }
+
+                    items.plenty({ respGroup: 'ItemInfo' }, productIds, function (products) {
+                        var productsById = _.indexBy(products, 'id');
+
+                        blade.currentEntities = _.filter(inventoryList, function (inventory) {
+                            var product = productsById[inventory.productId];
+                            if (product) {
+                                inventory.productName = product.name;
+                                inventory.productCode = product.code;
+                            }
+                            return product;
+                        });
+
+                        blade.isLoading = false;
+                    }, function (error) {
+                        blade.isLoading = false;
+                        bladeNavigationService.setError('Error ' + error.status, blade);
+                    });
+                }
+
+                blade.toolbarCommands = [
+                    {
+                        name: "platform.commands.refresh", icon: 'fa fa-refresh',
+                        executeMethod: blade.refresh,
+                        canExecuteMethod: function () {
+                            return true;
+                        }
+                    }
+                ];
+
+                // ui-grid
+                $scope.setGridOptions = function (gridOptions) {
+                    uiGridHelper.initialize($scope, gridOptions, function (gridApi) {
+                        uiGridHelper.bindRefreshOnSortChanged($scope);
+                    });
+                    bladeUtils.initializePagination($scope);
+                };
+            }]);

--- a/src/VirtoCommerce.InventoryModule.Web/Scripts/blades/fulfillment-center-products-list.js
+++ b/src/VirtoCommerce.InventoryModule.Web/Scripts/blades/fulfillment-center-products-list.js
@@ -158,14 +158,13 @@ angular.module('virtoCommerce.inventoryModule')
 
                         if (!newInventories.length) {
                             bladeNavigationService.closeBlade(selectBlade);
+                            showAddedProducts();
                             return;
                         }
 
                         inventories.upsert(newInventories, function () {
                             bladeNavigationService.closeBlade(selectBlade);
-                            // the added products have no stock yet, so they are hidden by the default filter
-                            filter.inStockOnly = false;
-                            filter.criteriaChanged();
+                            showAddedProducts();
                         }, function (error) {
                             selectBlade.isLoading = false;
                             bladeNavigationService.setError('Error ' + error.status, selectBlade);
@@ -174,6 +173,13 @@ angular.module('virtoCommerce.inventoryModule')
                         selectBlade.isLoading = false;
                         bladeNavigationService.setError('Error ' + error.status, selectBlade);
                     });
+                }
+
+                // The added products have no stock yet and the products that already existed may have none either,
+                // so the default filter would hide them all and the add action would look like it did nothing.
+                function showAddedProducts() {
+                    filter.inStockOnly = false;
+                    filter.criteriaChanged();
                 }
 
                 blade.toolbarCommands = [

--- a/src/VirtoCommerce.InventoryModule.Web/Scripts/blades/fulfillment-center-products-list.tpl.html
+++ b/src/VirtoCommerce.InventoryModule.Web/Scripts/blades/fulfillment-center-products-list.tpl.html
@@ -1,0 +1,32 @@
+<div class="blade-static __bottom" ng-if="pageSettings.itemsPerPageCount < pageSettings.totalItems"
+     ng-include="'pagerTemplate.html'"></div>
+
+<div class="blade-content __xlarge-wide">
+  <div class="blade-inner">
+    <div class="table-wrapper" ng-init="setGridOptions({
+            useExternalSorting: true,
+            columnDefs: [{
+                name: 'productName',
+                displayName: 'inventory.blades.fulfillment-center-products-list.labels.product-name',
+                enableSorting: false
+            }, {
+                name: 'productCode',
+                displayName: 'inventory.blades.fulfillment-center-products-list.labels.product-code',
+                enableSorting: false,
+                width: 160
+            }, {
+                name: 'inStockQuantity',
+                displayName: 'inventory.blades.fulfillment-center-products-list.labels.in-stock-quantity',
+                width: 130,
+                sort: { direction: uiGridConstants.DESC }
+            }, {
+                name: 'reservedQuantity',
+                displayName: 'inventory.blades.fulfillment-center-products-list.labels.reserved-quantity',
+                width: 130
+            }]
+        })">
+      <div ui-grid="gridOptions" ui-grid-auto-resize ui-grid-save-state ui-grid-resize-columns ui-grid-move-columns
+           ui-grid-pinning ui-grid-height></div>
+    </div>
+  </div>
+</div>

--- a/src/VirtoCommerce.InventoryModule.Web/Scripts/blades/fulfillment-center-products-list.tpl.html
+++ b/src/VirtoCommerce.InventoryModule.Web/Scripts/blades/fulfillment-center-products-list.tpl.html
@@ -1,16 +1,37 @@
+<div class="blade-static">
+  <div class="form-group">
+    <label class="form-control __checkbox">
+      <input type="checkbox" ng-model="filter.inStockOnly" ng-change="filter.criteriaChanged()">
+      <span class="check"></span>
+      <span class="name">{{ 'inventory.blades.fulfillment-center-products-list.labels.in-stock-only' | translate }}</span>
+    </label>
+  </div>
+</div>
+
 <div class="blade-static __bottom" ng-if="pageSettings.itemsPerPageCount < pageSettings.totalItems"
      ng-include="'pagerTemplate.html'"></div>
 
 <div class="blade-content __xlarge-wide">
   <div class="blade-inner">
-    <div class="table-wrapper" ng-init="setGridOptions({
+    <div class="inner-block" ng-init="setGridOptions({
             useExternalSorting: true,
+            rowHeight: 60,
+            rowTemplate: 'list.row.html',
             columnDefs: [{
-                name: 'productName',
-                displayName: 'inventory.blades.fulfillment-center-products-list.labels.product-name',
-                enableSorting: false
+                name: 'product.imgSrc',
+                displayName: 'inventory.blades.fulfillment-center-products-list.labels.picture',
+                enableSorting: false,
+                enableColumnResizing: false,
+                width: 60,
+                cellTemplate: 'icon.cell.html'
             }, {
-                name: 'productCode',
+                name: 'product.name',
+                displayName: 'inventory.blades.fulfillment-center-products-list.labels.product-name',
+                enableSorting: false,
+                cellTooltip: true,
+                width: '***'
+            }, {
+                name: 'product.code',
                 displayName: 'inventory.blades.fulfillment-center-products-list.labels.product-code',
                 enableSorting: false,
                 width: 160
@@ -18,15 +39,49 @@
                 name: 'inStockQuantity',
                 displayName: 'inventory.blades.fulfillment-center-products-list.labels.in-stock-quantity',
                 width: 130,
-                sort: { direction: uiGridConstants.DESC }
+                sort: { direction: uiGridConstants.DESC, priority: 0 },
+                sortDirectionCycle: [uiGridConstants.DESC, uiGridConstants.ASC],
+                cellTemplate: 'inStockQuantity.cell.html'
             }, {
                 name: 'reservedQuantity',
                 displayName: 'inventory.blades.fulfillment-center-products-list.labels.reserved-quantity',
-                width: 130
+                width: 130,
+                sortDirectionCycle: [uiGridConstants.DESC, uiGridConstants.ASC],
+                cellTemplate: 'reservedQuantity.cell.html'
             }]
         })">
-      <div ui-grid="gridOptions" ui-grid-auto-resize ui-grid-save-state ui-grid-resize-columns ui-grid-move-columns
-           ui-grid-pinning ui-grid-height></div>
+      <div class="table-wrapper" ng-if="blade.currentEntities.length">
+        <div ui-grid="gridOptions" ui-grid-auto-resize ui-grid-save-state ui-grid-resize-columns ui-grid-move-columns
+             ui-grid-pinning ui-grid-height></div>
+      </div>
+      <div class="note" ng-if="!blade.currentEntities.length && !blade.isLoading">{{ 'platform.list.no-data' | translate }}</div>
     </div>
   </div>
 </div>
+
+<script type="text/ng-template" id="list.row.html">
+  <div ng-click="grid.appScope.selectNode(row.entity)"
+       ng-repeat="(colRenderIndex, col) in colContainer.renderedColumns track by col.uid"
+       ui-grid-one-bind-id-grid="rowRenderIndex + '-' + col.uid + '-cell'"
+       class="ui-grid-cell"
+       ng-class="{'ui-grid-row-header-cell': col.isRowHeader, '__selected': row.entity.productId === grid.appScope.selectedNodeId, 'table-descr': row.entity.product.name === grid.appScope.noProductName}"
+       role="{{col.isRowHeader ? 'rowheader' : 'gridcell' }}"
+       ui-grid-cell></div>
+</script>
+
+<script type="text/ng-template" id="icon.cell.html">
+  <div class="ui-grid-cell-contents">
+    <div class="product-img">
+      <div class="image" style="background-image: url('{{COL_FIELD}}')" ng-if="COL_FIELD"></div>
+      <em class="table-ico fas fa-image" ng-if="!COL_FIELD"></em>
+    </div>
+  </div>
+</script>
+
+<script type="text/ng-template" id="inStockQuantity.cell.html">
+  <div class="ui-grid-cell-contents">{{row.entity.inventory.inStockQuantity | number:0}}</div>
+</script>
+
+<script type="text/ng-template" id="reservedQuantity.cell.html">
+  <div class="ui-grid-cell-contents">{{row.entity.inventory.reservedQuantity | number:0}}</div>
+</script>

--- a/src/VirtoCommerce.InventoryModule.Web/Scripts/blades/inventory-detail.js
+++ b/src/VirtoCommerce.InventoryModule.Web/Scripts/blades/inventory-detail.js
@@ -5,9 +5,12 @@ angular.module('virtoCommerce.inventoryModule')
 
     blade.refresh = function() {
         blade.isLoading = true;
-        blade.parentBlade.refresh().then(function(results) {
-            var data = _.findWhere(results, { fulfillmentCenterId: blade.data.fulfillmentCenterId });
+        // blade.getEntity is set by the parent blades that keep a single inventory per product
+        var promise = blade.getEntity ? blade.getEntity() : blade.parentBlade.refresh().then(function(results) {
+            return _.findWhere(results, { fulfillmentCenterId: blade.data.fulfillmentCenterId });
+        });
 
+        promise.then(function(data) {
             initializeBlade(angular.copy(data));
         });
     };

--- a/src/VirtoCommerce.InventoryModule.Web/Scripts/inventory.js
+++ b/src/VirtoCommerce.InventoryModule.Web/Scripts/inventory.js
@@ -55,6 +55,12 @@ angular.module(moduleName, [])
                 }, 'fulfillmentCenterDetail');
 
                 widgetService.registerWidget({
+                    isVisible: function (blade) { return blade.currentEntityId && authService.checkPermission('inventory:read'); },
+                    controller: 'virtoCommerce.inventoryModule.fulfillmentCenterProductsWidgetController',
+                    template: 'Modules/$(VirtoCommerce.Inventory)/Scripts/widgets/fulfillmentCenterProductsWidget.tpl.html'
+                }, 'fulfillmentCenterDetail');
+
+                widgetService.registerWidget({
                     controller: 'platformWebApp.dynamicPropertyWidgetController',
                     template: '$(Platform)/Scripts/app/dynamicProperties/widgets/dynamicPropertyWidget.tpl.html',
                     isVisible: function (blade) { return blade.currentEntityId && authService.checkPermission('platform:dynamic_properties:read'); }

--- a/src/VirtoCommerce.InventoryModule.Web/Scripts/resources/inventory.js
+++ b/src/VirtoCommerce.InventoryModule.Web/Scripts/resources/inventory.js
@@ -3,6 +3,7 @@ angular.module('virtoCommerce.inventoryModule')
     return $resource('api/inventory/products/:id', { id: '@Id' }, {
         // query: { },
         update: { method: 'PUT' },
-        search: { method: 'POST', url: 'api/inventory/search' }
+        upsert: { method: 'PUT', url: 'api/inventory/plenty' },
+        searchProducts: { method: 'POST', url: 'api/inventory/products/search' }
     });
 }]);

--- a/src/VirtoCommerce.InventoryModule.Web/Scripts/resources/inventory.js
+++ b/src/VirtoCommerce.InventoryModule.Web/Scripts/resources/inventory.js
@@ -2,6 +2,7 @@ angular.module('virtoCommerce.inventoryModule')
 .factory('virtoCommerce.inventoryModule.inventories', ['$resource', function ($resource) {
     return $resource('api/inventory/products/:id', { id: '@Id' }, {
         // query: { },
-        update: { method: 'PUT' }
+        update: { method: 'PUT' },
+        search: { method: 'POST', url: 'api/inventory/search' }
     });
 }]);

--- a/src/VirtoCommerce.InventoryModule.Web/Scripts/widgets/fulfillmentCenterProductsWidget.js
+++ b/src/VirtoCommerce.InventoryModule.Web/Scripts/widgets/fulfillmentCenterProductsWidget.js
@@ -1,0 +1,33 @@
+angular.module('virtoCommerce.inventoryModule')
+    .controller('virtoCommerce.inventoryModule.fulfillmentCenterProductsWidgetController',
+        [
+            '$scope',
+            'platformWebApp.bladeNavigationService',
+            'virtoCommerce.inventoryModule.inventories',
+            function ($scope, bladeNavigationService, inventories) {
+                var blade = $scope.widget.blade;
+
+                function refresh() {
+                    inventories.search({
+                        fulfillmentCenterIds: [blade.currentEntityId],
+                        withNonZeroQuantityOnly: true,
+                        take: 0
+                    }, function (data) {
+                        $scope.productsCount = data.totalCount;
+                    });
+                }
+
+                $scope.openBlade = function () {
+                    var newBlade = {
+                        id: 'fulfillmentCenterProductsList',
+                        currentEntityId: blade.currentEntityId,
+                        title: blade.title,
+                        subtitle: 'inventory.widgets.fulfillmentCenterProductsWidget.blade-subtitle',
+                        controller: 'virtoCommerce.inventoryModule.fulfillmentCenterProductsListController',
+                        template: 'Modules/$(VirtoCommerce.Inventory)/Scripts/blades/fulfillment-center-products-list.tpl.html'
+                    };
+                    bladeNavigationService.showBlade(newBlade, blade);
+                };
+
+                refresh();
+            }]);

--- a/src/VirtoCommerce.InventoryModule.Web/Scripts/widgets/fulfillmentCenterProductsWidget.js
+++ b/src/VirtoCommerce.InventoryModule.Web/Scripts/widgets/fulfillmentCenterProductsWidget.js
@@ -8,9 +8,9 @@ angular.module('virtoCommerce.inventoryModule')
                 var blade = $scope.widget.blade;
 
                 function refresh() {
-                    inventories.search({
+                    inventories.searchProducts({
                         fulfillmentCenterIds: [blade.currentEntityId],
-                        withNonZeroQuantityOnly: true,
+                        withPositiveQuantityOnly: true,
                         take: 0
                     }, function (data) {
                         $scope.productsCount = data.totalCount;
@@ -23,6 +23,7 @@ angular.module('virtoCommerce.inventoryModule')
                         currentEntityId: blade.currentEntityId,
                         title: blade.title,
                         subtitle: 'inventory.widgets.fulfillmentCenterProductsWidget.blade-subtitle',
+                        parentWidgetRefresh: refresh,
                         controller: 'virtoCommerce.inventoryModule.fulfillmentCenterProductsListController',
                         template: 'Modules/$(VirtoCommerce.Inventory)/Scripts/blades/fulfillment-center-products-list.tpl.html'
                     };

--- a/src/VirtoCommerce.InventoryModule.Web/Scripts/widgets/fulfillmentCenterProductsWidget.tpl.html
+++ b/src/VirtoCommerce.InventoryModule.Web/Scripts/widgets/fulfillmentCenterProductsWidget.tpl.html
@@ -1,6 +1,6 @@
 <div class="gridster-cnt" ng-click="openBlade()">
     <div class="cnt-inner">
-        <div class="list-count" ng-if="productsCount">{{productsCount | number:0}}</div>
+        <div class="list-count" ng-if="productsCount !== undefined">{{productsCount | number:0}}</div>
         <div class="list-t">{{ 'inventory.widgets.fulfillmentCenterProductsWidget.title' | translate }}</div>
     </div>
 </div>

--- a/src/VirtoCommerce.InventoryModule.Web/Scripts/widgets/fulfillmentCenterProductsWidget.tpl.html
+++ b/src/VirtoCommerce.InventoryModule.Web/Scripts/widgets/fulfillmentCenterProductsWidget.tpl.html
@@ -1,0 +1,6 @@
+<div class="gridster-cnt" ng-click="openBlade()">
+    <div class="cnt-inner">
+        <div class="list-count" ng-if="productsCount">{{productsCount | number:0}}</div>
+        <div class="list-t">{{ 'inventory.widgets.fulfillmentCenterProductsWidget.title' | translate }}</div>
+    </div>
+</div>

--- a/src/VirtoCommerce.InventoryModule.Web/VirtoCommerce.InventoryModule.Web.csproj
+++ b/src/VirtoCommerce.InventoryModule.Web/VirtoCommerce.InventoryModule.Web.csproj
@@ -21,6 +21,9 @@
     <None Remove="node_modules\**" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1000.0" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.InventoryModule.Core\VirtoCommerce.InventoryModule.Core.csproj" />
     <ProjectReference Include="..\VirtoCommerce.InventoryModule.Data.MySql\VirtoCommerce.InventoryModule.Data.MySql.csproj" />
     <ProjectReference Include="..\VirtoCommerce.InventoryModule.Data.PostgreSql\VirtoCommerce.InventoryModule.Data.PostgreSql.csproj" />

--- a/src/VirtoCommerce.InventoryModule.Web/module.manifest
+++ b/src/VirtoCommerce.InventoryModule.Web/module.manifest
@@ -6,6 +6,7 @@
 
   <platformVersion>3.1039.0</platformVersion>
   <dependencies>
+    <dependency id="VirtoCommerce.Assets" version="3.1000.0" />
     <dependency id="VirtoCommerce.Catalog" version="3.1029.0" />
     <dependency id="VirtoCommerce.Core" version="3.1007.0" />
     <dependency id="VirtoCommerce.Search" version="3.1004.0" />

--- a/tests/VirtoCommerce.InventoryModule.Tests/InventorySearchServiceTests.cs
+++ b/tests/VirtoCommerce.InventoryModule.Tests/InventorySearchServiceTests.cs
@@ -50,7 +50,7 @@ public class InventorySearchServiceTests : InventoryTestsBase
     }
 
     [Fact]
-    public async Task SearchAsync_WithNonZeroQuantityOnly_ShouldReturnInventoriesWithStockOnly()
+    public async Task SearchAsync_WithPositiveQuantityOnly_ShouldReturnInventoriesInStockOnly()
     {
         // Arrange
         var fulfillmentCenterId = NewId();
@@ -66,14 +66,14 @@ public class InventorySearchServiceTests : InventoryTestsBase
         var criteria = new InventorySearchCriteria
         {
             FulfillmentCenterIds = [fulfillmentCenterId],
-            WithNonZeroQuantityOnly = true,
+            WithPositiveQuantityOnly = true,
         };
 
         // Act
         var result = await searchService.SearchAsync(criteria);
 
         // Assert
-        Assert.Equal(2, result.TotalCount);
-        Assert.Equal(new List<string> { _productId1, _productId3 }, result.Results.Select(x => x.ProductId).OrderBy(x => x).ToList());
+        Assert.Equal(1, result.TotalCount);
+        Assert.Equal(new List<string> { _productId1 }, result.Results.Select(x => x.ProductId).ToList());
     }
 }

--- a/tests/VirtoCommerce.InventoryModule.Tests/InventorySearchServiceTests.cs
+++ b/tests/VirtoCommerce.InventoryModule.Tests/InventorySearchServiceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using VirtoCommerce.InventoryModule.Core.Model;
@@ -46,5 +47,33 @@ public class InventorySearchServiceTests : InventoryTestsBase
 
         // Returned collections should be different instances with equal but not the same objects
         AssertEqualButNotSame(result1, result2);
+    }
+
+    [Fact]
+    public async Task SearchAsync_WithNonZeroQuantityOnly_ShouldReturnInventoriesWithStockOnly()
+    {
+        // Arrange
+        var fulfillmentCenterId = NewId();
+        var crudService = GetInventoryService();
+        var searchService = GetInventorySearchService();
+
+        await crudService.SaveChangesAsync([
+            new InventoryInfo { Id = NewId(), FulfillmentCenterId = fulfillmentCenterId, ProductId = _productId1, InStockQuantity = 5 },
+            new InventoryInfo { Id = NewId(), FulfillmentCenterId = fulfillmentCenterId, ProductId = _productId2, InStockQuantity = 0 },
+            new InventoryInfo { Id = NewId(), FulfillmentCenterId = fulfillmentCenterId, ProductId = _productId3, InStockQuantity = -3 },
+        ]);
+
+        var criteria = new InventorySearchCriteria
+        {
+            FulfillmentCenterIds = [fulfillmentCenterId],
+            WithNonZeroQuantityOnly = true,
+        };
+
+        // Act
+        var result = await searchService.SearchAsync(criteria);
+
+        // Assert
+        Assert.Equal(2, result.TotalCount);
+        Assert.Equal(new List<string> { _productId1, _productId3 }, result.Results.Select(x => x.ProductId).OrderBy(x => x).ToList());
     }
 }

--- a/tests/VirtoCommerce.InventoryModule.Tests/ProductChangedEventHandlerTests.cs
+++ b/tests/VirtoCommerce.InventoryModule.Tests/ProductChangedEventHandlerTests.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Moq;
+using VirtoCommerce.CatalogModule.Core.Events;
+using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.InventoryModule.Core.Model;
+using VirtoCommerce.InventoryModule.Core.Services;
+using VirtoCommerce.InventoryModule.Data.Handlers;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Events;
+using Xunit;
+
+namespace VirtoCommerce.InventoryModule.Tests;
+
+[Trait("Category", "Unit")]
+public class ProductChangedEventHandlerTests : InventoryTestsBase
+{
+    private const string _productId1 = "1";
+    private const string _productId2 = "2";
+
+    [Fact]
+    public async Task Handle_ProductDeleted_ShouldDeleteItsInventories()
+    {
+        // Arrange
+        var inventoryId1 = NewId();
+        var inventoryId2 = NewId();
+
+        await GetInventoryService().SaveChangesAsync([
+            new InventoryInfo { Id = inventoryId1, FulfillmentCenterId = NewId(), ProductId = _productId1 },
+            new InventoryInfo { Id = inventoryId2, FulfillmentCenterId = NewId(), ProductId = _productId1 },
+            new InventoryInfo { Id = NewId(), FulfillmentCenterId = NewId(), ProductId = _productId2 },
+        ]);
+
+        var inventoryServiceMock = new Mock<IInventoryService>();
+        var handler = new ProductChangedEventHandler(GetInventorySearchService(), inventoryServiceMock.Object);
+
+        // Act
+        await handler.Handle(GetEvent(EntryState.Deleted, _productId1));
+
+        // Assert
+        inventoryServiceMock.Verify(x => x.DeleteAsync(
+            It.Is<IList<string>>(ids => ids.Count == 2 && ids.Contains(inventoryId1) && ids.Contains(inventoryId2)),
+            It.IsAny<bool>()));
+    }
+
+    [Theory]
+    [InlineData(EntryState.Added)]
+    [InlineData(EntryState.Modified)]
+    [InlineData(EntryState.Unchanged)]
+    public async Task Handle_ProductNotDeleted_ShouldKeepItsInventories(EntryState entryState)
+    {
+        // Arrange
+        await GetInventoryService().SaveChangesAsync([
+            new InventoryInfo { Id = NewId(), FulfillmentCenterId = NewId(), ProductId = _productId1 },
+        ]);
+
+        var inventoryServiceMock = new Mock<IInventoryService>();
+        var handler = new ProductChangedEventHandler(GetInventorySearchService(), inventoryServiceMock.Object);
+
+        // Act
+        await handler.Handle(GetEvent(entryState, _productId1));
+
+        // Assert
+        inventoryServiceMock.Verify(x => x.DeleteAsync(It.IsAny<IList<string>>(), It.IsAny<bool>()), Times.Never);
+    }
+
+    private static ProductChangedEvent GetEvent(EntryState entryState, string productId)
+    {
+        return new ProductChangedEvent([new GenericChangedEntry<CatalogProduct>(new CatalogProduct { Id = productId }, entryState)]);
+    }
+}


### PR DESCRIPTION
## Description
<img width="795" height="847" alt="image" src="https://github.com/user-attachments/assets/17380378-7ac8-42cd-896d-a761f762b34b" />

<img width="811" height="934" alt="image" src="https://github.com/user-attachments/assets/c74269c1-afc7-4c76-9ec6-e9cac3d08439" />

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5546
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Inventory_3.1005.0-pr-163-d96c.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New catalog-coupled API and automatic inventory deletion on product delete affect inventory data integrity; UI and search changes are moderate in scope.
> 
> **Overview**
> Adds **fulfillment-center product stock management** in the admin UI: a **Products** widget on fulfillment center detail opens a blade that lists inventories with catalog fields (image, name, SKU), in-stock and reserved quantities, an **in stock only** filter, and actions to add products from the catalog and edit inventory per row.
> 
> **Backend** introduces `POST inventory/products/search`, which returns `ProductInventoryInfo` (inventory plus server-resolved catalog product and absolute image URLs) so callers only need inventory read permission. Search criteria gain **`WithPositiveQuantityOnly`** (`InStockQuantity > 0`). **`ProductChangedEventHandler`** removes inventory rows when catalog products are deleted. Module dependencies add **Catalog** and **Assets**.
> 
> **Inventory detail** refresh supports an optional **`blade.getEntity`** callback from parent blades. Unit tests cover the positive-quantity filter and product-deletion cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d96c11aa02fb786fd50928b5f95a0d6eceff99e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->