### PR TITLE
VCST-5490: use BackgroundJobs

### DIFF
--- a/src/VirtoCommerce.InventoryModule.Core/VirtoCommerce.InventoryModule.Core.csproj
+++ b/src/VirtoCommerce.InventoryModule.Core/VirtoCommerce.InventoryModule.Core.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1007.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1052.0" />
     <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1004.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.InventoryModule.Data.MySql/VirtoCommerce.InventoryModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.InventoryModule.Data.MySql/VirtoCommerce.InventoryModule.Data.MySql.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.InventoryModule.Data\VirtoCommerce.InventoryModule.Data.csproj" />

--- a/src/VirtoCommerce.InventoryModule.Data.PostgreSql/VirtoCommerce.InventoryModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.InventoryModule.Data.PostgreSql/VirtoCommerce.InventoryModule.Data.PostgreSql.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.InventoryModule.Data\VirtoCommerce.InventoryModule.Data.csproj" />

--- a/src/VirtoCommerce.InventoryModule.Data.SqlServer/VirtoCommerce.InventoryModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.InventoryModule.Data.SqlServer/VirtoCommerce.InventoryModule.Data.SqlServer.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.InventoryModule.Data\VirtoCommerce.InventoryModule.Data.csproj" />

--- a/src/VirtoCommerce.InventoryModule.Data/Handlers/FulfillmentCenterChangedEventHandler.cs
+++ b/src/VirtoCommerce.InventoryModule.Data/Handlers/FulfillmentCenterChangedEventHandler.cs
@@ -1,11 +1,13 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Hangfire;
 using VirtoCommerce.InventoryModule.Core.Events;
 using VirtoCommerce.InventoryModule.Core.Services;
 using VirtoCommerce.InventoryModule.Data.Caching;
+using VirtoCommerce.InventoryModule.Data.Jobs;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Events;
+using VirtoCommerce.Platform.Core.Jobs;
 
 namespace VirtoCommerce.InventoryModule.Data.Handlers
 {
@@ -18,7 +20,7 @@ namespace VirtoCommerce.InventoryModule.Data.Handlers
             _fulfillmentCenterGeoService = fulfillmentCenterGeoService;
         }
 
-        public Task Handle(FulfillmentCenterChangedEvent message)
+        public async Task Handle(FulfillmentCenterChangedEvent message)
         {
             var invalidate = message.ChangedEntries.Any(entry =>
                 (entry.EntryState == EntryState.Modified && entry.NewEntry?.GeoLocation != entry.OldEntry?.GeoLocation) ||
@@ -27,13 +29,25 @@ namespace VirtoCommerce.InventoryModule.Data.Handlers
 
             if (invalidate)
             {
-                BackgroundJob.Enqueue(() => RecalculateFFDistance());
-            }
+                var payload = AbstractTypeFactory<RecalculateFulfillmentCenterDistanceJobPayload>.TryCreateInstance();
 
-            return Task.CompletedTask;
+                // The static facade, not an injected IBackgroundJob: RegisterEventHandler resolves this handler once from
+                // the root provider and holds it for the process lifetime, so it must not capture a Scoped dependency.
+                await BackgroundJob.Enqueue<RecalculateFulfillmentCenterDistanceJobHandler>(payload);
+            }
         }
 
-        [DisableConcurrentExecution(10)]
+        /// <summary>
+        /// Kept for background jobs enqueued by an earlier version, which reference this method by name.
+        /// New work goes through <see cref="RecalculateFulfillmentCenterDistanceJobHandler"/>; remove this once no
+        /// such job can still be pending.
+        /// </summary>
+        // Signature is byte-identical on purpose: Hangfire persists a queued job as type name + method name +
+        // parameter types + serialized args, so changing any of them would strand already-queued jobs as Failed.
+        // The [DisableConcurrentExecution(10)] that guarded it is gone with the Hangfire reference and has no
+        // equivalent in the engine-agnostic API. Overlapping runs only duplicate work: the body expires a cache
+        // region and re-reads it, so a second run recomputes the same values rather than corrupting them.
+        [Obsolete("Enqueued indirectly by legacy Hangfire jobs only; new work uses RecalculateFulfillmentCenterDistanceJobHandler.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
         public virtual async Task RecalculateFFDistance()
         {
             FulfillmentCenterGeoCacheRegion.ExpireRegion();

--- a/src/VirtoCommerce.InventoryModule.Data/Handlers/LogChangesChangedEventHandler.cs
+++ b/src/VirtoCommerce.InventoryModule.Data/Handlers/LogChangesChangedEventHandler.cs
@@ -1,11 +1,13 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Hangfire;
 using VirtoCommerce.InventoryModule.Core;
 using VirtoCommerce.InventoryModule.Core.Events;
+using VirtoCommerce.InventoryModule.Data.Jobs;
 using VirtoCommerce.Platform.Core.ChangeLog;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Events;
+using VirtoCommerce.Platform.Core.Jobs;
 using VirtoCommerce.Platform.Core.Settings;
 
 namespace VirtoCommerce.InventoryModule.Data.Handlers
@@ -35,8 +37,16 @@ namespace VirtoCommerce.InventoryModule.Data.Handlers
             if (logInventoryChangesEnabled)
             {
                 var logOperations = @event.ChangedEntries.Select(x => AbstractTypeFactory<OperationLog>.TryCreateInstance().FromChangedEntry(x)).ToArray();
-                //Background task is used here for performance reasons
-                BackgroundJob.Enqueue(() => LogEntityChangesInBackground(logOperations));
+
+                var payload = AbstractTypeFactory<LogEntityChangesJobPayload>.TryCreateInstance();
+                payload.OperationLogs = logOperations;
+
+                // Background task is used here for performance reasons.
+                // The static facade, not an injected IBackgroundJob: RegisterEventHandler resolves this handler once from
+                // the root provider and holds it for the process lifetime, so it must not capture a Scoped dependency.
+                // Enqueued even for an empty batch, on purpose: SaveChangesAsync ends in Reset(), and the else branch
+                // below shows that resetting the last-modified date on every inventory change is the intended behavior.
+                await BackgroundJob.Enqueue<LogEntityChangesJobHandler>(payload);
             }
             else
             {
@@ -45,7 +55,15 @@ namespace VirtoCommerce.InventoryModule.Data.Handlers
             }
         }
 
+        /// <summary>
+        /// Kept for background jobs enqueued by an earlier version, which reference this method by name.
+        /// New work goes through <see cref="LogEntityChangesJobHandler"/>; remove this once no such job
+        /// can still be pending.
+        /// </summary>
+        // Signature is byte-identical on purpose: Hangfire persists a queued job as type name + method name +
+        // parameter types + serialized args, so changing any of them would strand already-queued entries as Failed.
         // (!) Do not make this method async, it causes improper user recorded into the log! It happens because the user stored in the current thread. If the thread switched, the user info will lost.
+        [Obsolete("Enqueued indirectly by legacy Hangfire jobs only; new work uses LogEntityChangesJobHandler.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
         public void LogEntityChangesInBackground(OperationLog[] operationLogs)
         {
             _changeLogService.SaveChangesAsync(operationLogs).GetAwaiter().GetResult();

--- a/src/VirtoCommerce.InventoryModule.Data/Jobs/LogEntityChangesJobHandler.cs
+++ b/src/VirtoCommerce.InventoryModule.Data/Jobs/LogEntityChangesJobHandler.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.Platform.Core.ChangeLog;
+using VirtoCommerce.Platform.Core.Jobs;
+
+namespace VirtoCommerce.InventoryModule.Data.Jobs
+{
+    /// <summary>
+    /// Persists the change-log entries collected by <see cref="Handlers.LogChangesChangedEventHandler"/>, off the request thread.
+    /// </summary>
+    /// <remarks>
+    /// Awaiting here is safe, unlike in the Hangfire method this replaces: the engine restores the enqueuing user into
+    /// the job's scope before Execute, and <c>IUserNameResolver</c> holds it in an AsyncLocal, which flows across
+    /// awaits - so <c>CreatedBy</c> on the written rows is the user who made the change, not the thread that resumed.
+    /// </remarks>
+    public class LogEntityChangesJobHandler(IChangeLogService changeLogService) : IBackgroundJobHandler<LogEntityChangesJobPayload>
+    {
+        public virtual Task Execute(LogEntityChangesJobPayload payload, IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return changeLogService.SaveChangesAsync(payload.OperationLogs);
+        }
+    }
+}

--- a/src/VirtoCommerce.InventoryModule.Data/Jobs/LogEntityChangesJobPayload.cs
+++ b/src/VirtoCommerce.InventoryModule.Data/Jobs/LogEntityChangesJobPayload.cs
@@ -1,0 +1,12 @@
+using VirtoCommerce.Platform.Core.ChangeLog;
+
+namespace VirtoCommerce.InventoryModule.Data.Jobs
+{
+    /// <summary>
+    /// Payload of the background job that persists inventory change-log entries.
+    /// </summary>
+    public class LogEntityChangesJobPayload
+    {
+        public OperationLog[] OperationLogs { get; set; }
+    }
+}

--- a/src/VirtoCommerce.InventoryModule.Data/Jobs/RecalculateFulfillmentCenterDistanceJobHandler.cs
+++ b/src/VirtoCommerce.InventoryModule.Data/Jobs/RecalculateFulfillmentCenterDistanceJobHandler.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.InventoryModule.Core.Services;
+using VirtoCommerce.InventoryModule.Data.Caching;
+using VirtoCommerce.Platform.Core.Jobs;
+
+namespace VirtoCommerce.InventoryModule.Data.Jobs
+{
+    /// <summary>
+    /// Drops the cached fulfillment center distances and warms them again, off the request thread.
+    /// </summary>
+    public class RecalculateFulfillmentCenterDistanceJobHandler(IFulfillmentCenterGeoService fulfillmentCenterGeoService)
+        : IBackgroundJobHandler<RecalculateFulfillmentCenterDistanceJobPayload>
+    {
+        public virtual async Task Execute(RecalculateFulfillmentCenterDistanceJobPayload payload, IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            FulfillmentCenterGeoCacheRegion.ExpireRegion();
+
+            _ = await fulfillmentCenterGeoService.GetNearestAsync(string.Empty, default(int));
+        }
+    }
+}

--- a/src/VirtoCommerce.InventoryModule.Data/Jobs/RecalculateFulfillmentCenterDistanceJobPayload.cs
+++ b/src/VirtoCommerce.InventoryModule.Data/Jobs/RecalculateFulfillmentCenterDistanceJobPayload.cs
@@ -1,0 +1,11 @@
+namespace VirtoCommerce.InventoryModule.Data.Jobs
+{
+    /// <summary>
+    /// Payload of the background job that refreshes the cached fulfillment center distances. Carries no data: the job
+    /// recalculates everything, and the enqueue is a plain "the geo data changed" signal. It exists because the job
+    /// API is payload-addressed, and it stays a class so a partner module can extend it via AbstractTypeFactory.
+    /// </summary>
+    public class RecalculateFulfillmentCenterDistanceJobPayload
+    {
+    }
+}

--- a/src/VirtoCommerce.InventoryModule.Data/VirtoCommerce.InventoryModule.Data.csproj
+++ b/src/VirtoCommerce.InventoryModule.Data/VirtoCommerce.InventoryModule.Data.csproj
@@ -15,8 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.InventoryModule.Core\VirtoCommerce.InventoryModule.Core.csproj" />

--- a/src/VirtoCommerce.InventoryModule.Web/Module.cs
+++ b/src/VirtoCommerce.InventoryModule.Web/Module.cs
@@ -1,4 +1,4 @@
-using System;
+using System;
 using System.Threading;
 using System.Collections.Generic;
 using System.IO;
@@ -14,6 +14,7 @@ using VirtoCommerce.InventoryModule.Core.Model;
 using VirtoCommerce.InventoryModule.Core.Services;
 using VirtoCommerce.InventoryModule.Data.ExportImport;
 using VirtoCommerce.InventoryModule.Data.Handlers;
+using VirtoCommerce.InventoryModule.Data.Jobs;
 using VirtoCommerce.InventoryModule.Data.MySql;
 using VirtoCommerce.InventoryModule.Data.PostgreSql;
 using VirtoCommerce.InventoryModule.Data.Repositories;
@@ -24,6 +25,7 @@ using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.DynamicProperties;
 using VirtoCommerce.Platform.Core.Events;
 using VirtoCommerce.Platform.Core.ExportImport;
+using VirtoCommerce.Platform.Core.Jobs;
 using VirtoCommerce.Platform.Core.Modularity;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.Platform.Core.Settings;
@@ -78,6 +80,11 @@ namespace VirtoCommerce.InventoryModule.Web
             serviceCollection.AddTransient<LogChangesChangedEventHandler>();
             serviceCollection.AddTransient<IndexInventoryChangedEventHandler>();
             serviceCollection.AddTransient<FulfillmentCenterChangedEventHandler>();
+
+            // Not triggerable by name: this job writes audit-log rows, and an OperationLog whose Id matches an existing
+            // row takes ChangeLogService.SaveChangesAsync's Patch branch, so a caller-supplied payload must never reach it.
+            serviceCollection.AddBackgroundJob<LogEntityChangesJobHandler, LogEntityChangesJobPayload>(triggerable: false);
+            serviceCollection.AddBackgroundJob<RecalculateFulfillmentCenterDistanceJobHandler, RecalculateFulfillmentCenterDistanceJobPayload>();
         }
 
         public void PostInitialize(IApplicationBuilder appBuilder)

--- a/src/VirtoCommerce.InventoryModule.Web/module.manifest
+++ b/src/VirtoCommerce.InventoryModule.Web/module.manifest
@@ -6,7 +6,6 @@
 
   <platformVersion>3.1052.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.BackgroundJobs" version="3.1050.0" />
     <dependency id="VirtoCommerce.Catalog" version="3.1029.0" />
     <dependency id="VirtoCommerce.Core" version="3.1007.0" />
     <dependency id="VirtoCommerce.Search" version="3.1004.0" />

--- a/src/VirtoCommerce.InventoryModule.Web/module.manifest
+++ b/src/VirtoCommerce.InventoryModule.Web/module.manifest
@@ -4,8 +4,9 @@
   <version>3.1005.0</version>
   <version-tag />
 
-  <platformVersion>3.1039.0</platformVersion>
+  <platformVersion>3.1052.0</platformVersion>
   <dependencies>
+    <dependency id="VirtoCommerce.BackgroundJobs" version="3.1050.0" />
     <dependency id="VirtoCommerce.Catalog" version="3.1029.0" />
     <dependency id="VirtoCommerce.Core" version="3.1007.0" />
     <dependency id="VirtoCommerce.Search" version="3.1004.0" />

--- a/tests/VirtoCommerce.InventoryModule.Tests/BackgroundJobEnqueueTests.cs
+++ b/tests/VirtoCommerce.InventoryModule.Tests/BackgroundJobEnqueueTests.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using VirtoCommerce.InventoryModule.Core.Events;
+using VirtoCommerce.InventoryModule.Core.Model;
+using VirtoCommerce.InventoryModule.Core.Services;
+using VirtoCommerce.InventoryModule.Data.Handlers;
+using VirtoCommerce.InventoryModule.Data.Jobs;
+using VirtoCommerce.Platform.Core.ChangeLog;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Events;
+using VirtoCommerce.Platform.Core.Jobs;
+using VirtoCommerce.Platform.Core.Settings;
+using Xunit;
+
+namespace VirtoCommerce.InventoryModule.Tests
+{
+    // Any other test class that enqueues through the static BackgroundJob facade must join this collection:
+    // the facade has no reset API (Initialize rejects null), so Dispose leaves a DISPOSED provider behind in
+    // the static, and a class racing this one would see ObjectDisposedException from it.
+    [Collection(nameof(BackgroundJobEnqueueTests))]
+    [Trait("Category", "Unit")]
+    public class BackgroundJobEnqueueTests
+    {
+        [Fact]
+        public async Task LogChanges_LoggingEnabled_EnqueuesOneJobWithOneLogPerChangedEntry()
+        {
+            //Arrange
+            using var capture = new EnqueueCapture();
+            var lastModifiedDateTime = new Mock<ILastModifiedDateTime>();
+            var handler = new LogChangesChangedEventHandler(Mock.Of<IChangeLogService>(), lastModifiedDateTime.Object, CreateSettingsManager(logInventoryChanges: true));
+
+            var message = new InventoryChangedEvent(
+            [
+                new GenericChangedEntry<InventoryInfo>(new InventoryInfo { Id = "inv1" }, new InventoryInfo { Id = "inv1" }, EntryState.Modified),
+                new GenericChangedEntry<InventoryInfo>(new InventoryInfo { Id = "inv2" }, new InventoryInfo { Id = "inv2" }, EntryState.Added),
+            ]);
+
+            //Act
+            await handler.Handle(message);
+
+            //Assert
+            var payload = Assert.IsType<LogEntityChangesJobPayload>(capture.Payload);
+            Assert.Equal(1, capture.EnqueueCount);
+            Assert.Equal(["inv1", "inv2"], payload.OperationLogs.Select(x => x.ObjectId));
+            Assert.Equal([EntryState.Modified, EntryState.Added], payload.OperationLogs.Select(x => x.OperationType));
+
+            // The job's SaveChangesAsync ends in Reset(), so the handler must not reset the date itself as well.
+            lastModifiedDateTime.Verify(x => x.Reset(), Times.Never);
+        }
+
+        [Fact]
+        public async Task LogChanges_LoggingDisabled_ResetsLastModifiedInsteadOfEnqueuing()
+        {
+            //Arrange
+            using var capture = new EnqueueCapture();
+            var lastModifiedDateTime = new Mock<ILastModifiedDateTime>();
+            var handler = new LogChangesChangedEventHandler(Mock.Of<IChangeLogService>(), lastModifiedDateTime.Object, CreateSettingsManager(logInventoryChanges: false));
+
+            var inventory = new InventoryInfo { Id = "inv1" };
+
+            //Act
+            await handler.Handle(new InventoryChangedEvent([new GenericChangedEntry<InventoryInfo>(inventory, inventory, EntryState.Modified)]));
+
+            //Assert
+            Assert.Equal(0, capture.EnqueueCount);
+            lastModifiedDateTime.Verify(x => x.Reset(), Times.Once);
+        }
+
+        [Fact]
+        public async Task LogEntityChangesJobHandler_SavesThePayloadLogs()
+        {
+            //Arrange
+            var operationLogs = new[] { AbstractTypeFactory<OperationLog>.TryCreateInstance() };
+            var changeLogServiceMock = new Mock<IChangeLogService>();
+
+            var handler = new LogEntityChangesJobHandler(changeLogServiceMock.Object);
+
+            //Act
+            await handler.Execute(new LogEntityChangesJobPayload { OperationLogs = operationLogs }, context: null,
+                TestContext.Current.CancellationToken);
+
+            //Assert
+            changeLogServiceMock.Verify(x => x.SaveChangesAsync(operationLogs), Times.Once);
+        }
+
+        [Fact]
+        public async Task FulfillmentCenterChanged_GeoLocationChanged_EnqueuesRecalculation()
+        {
+            //Arrange
+            using var capture = new EnqueueCapture();
+            var handler = new FulfillmentCenterChangedEventHandler(Mock.Of<IFulfillmentCenterGeoService>());
+
+            var message = new FulfillmentCenterChangedEvent(
+            [
+                new GenericChangedEntry<FulfillmentCenter>(
+                    new FulfillmentCenter { Id = "ffc1", GeoLocation = "1,1" },
+                    new FulfillmentCenter { Id = "ffc1", GeoLocation = "2,2" },
+                    EntryState.Modified),
+            ]);
+
+            //Act
+            await handler.Handle(message);
+
+            //Assert
+            Assert.Equal(1, capture.EnqueueCount);
+            Assert.IsType<RecalculateFulfillmentCenterDistanceJobPayload>(capture.Payload);
+        }
+
+        [Fact]
+        public async Task FulfillmentCenterChanged_GeoLocationUnchanged_EnqueuesNothing()
+        {
+            //Arrange
+            using var capture = new EnqueueCapture();
+            var handler = new FulfillmentCenterChangedEventHandler(Mock.Of<IFulfillmentCenterGeoService>());
+
+            var message = new FulfillmentCenterChangedEvent(
+            [
+                new GenericChangedEntry<FulfillmentCenter>(
+                    new FulfillmentCenter { Id = "ffc1", GeoLocation = "1,1", Name = "new name" },
+                    new FulfillmentCenter { Id = "ffc1", GeoLocation = "1,1", Name = "old name" },
+                    EntryState.Modified),
+            ]);
+
+            //Act
+            await handler.Handle(message);
+
+            //Assert
+            Assert.Equal(0, capture.EnqueueCount);
+        }
+
+        [Fact]
+        public async Task RecalculateFulfillmentCenterDistanceJobHandler_WarmsTheGeoCache()
+        {
+            //Arrange
+            var geoServiceMock = new Mock<IFulfillmentCenterGeoService>();
+            var handler = new RecalculateFulfillmentCenterDistanceJobHandler(geoServiceMock.Object);
+
+            //Act
+            await handler.Execute(new RecalculateFulfillmentCenterDistanceJobPayload(), context: null,
+                TestContext.Current.CancellationToken);
+
+            //Assert
+            geoServiceMock.Verify(x => x.GetNearestAsync(string.Empty, 0), Times.Once);
+        }
+
+        private static ISettingsManager CreateSettingsManager(bool logInventoryChanges)
+        {
+            var settingsManager = new Mock<ISettingsManager>();
+            settingsManager
+                .Setup(x => x.GetObjectSettingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new ObjectSettingEntry { Value = logInventoryChanges });
+
+            return settingsManager.Object;
+        }
+
+        // Captures what a handler enqueued through the static BackgroundJob facade. IBackgroundJob is registered
+        // Scoped here exactly as the engine module registers it, so this also proves the facade's per-call scope
+        // resolves it - the handlers themselves are root-resolved and must never hold it.
+        private sealed class EnqueueCapture : IDisposable
+        {
+            private readonly ServiceProvider _provider;
+
+            public EnqueueCapture()
+            {
+                BackgroundJobMock
+                    .Setup(x => x.Enqueue<LogEntityChangesJobHandler>(It.IsAny<object>(), It.IsAny<EnqueueOptions>(), It.IsAny<CancellationToken>()))
+                    .Callback<object, EnqueueOptions, CancellationToken>((payload, _, _) => Capture(payload))
+                    .ReturnsAsync("job-id");
+
+                BackgroundJobMock
+                    .Setup(x => x.Enqueue<RecalculateFulfillmentCenterDistanceJobHandler>(It.IsAny<object>(), It.IsAny<EnqueueOptions>(), It.IsAny<CancellationToken>()))
+                    .Callback<object, EnqueueOptions, CancellationToken>((payload, _, _) => Capture(payload))
+                    .ReturnsAsync("job-id");
+
+                var services = new ServiceCollection();
+                services.AddScoped(_ => BackgroundJobMock.Object);
+                _provider = services.BuildServiceProvider(validateScopes: true);
+
+                BackgroundJob.Initialize(_provider);
+            }
+
+            public Mock<IBackgroundJob> BackgroundJobMock { get; } = new();
+
+            public object Payload { get; private set; }
+
+            public int EnqueueCount { get; private set; }
+
+            public void Dispose()
+            {
+                _provider.Dispose();
+            }
+
+            private void Capture(object payload)
+            {
+                Payload = payload;
+                EnqueueCount++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5490
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Inventory_3.1007.0-pr-164-c7d2.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches async background processing and audit logging paths on every inventory change; requires platform 3.1052.0 and correct job engine configuration at runtime, with legacy Hangfire jobs still depending on obsolete handler methods until drained.
> 
> **Overview**
> **Migrates inventory off Hangfire** onto the platform **3.1052.0** job API: drops `VirtoCommerce.Platform.Hangfire`, bumps platform package references and `module.manifest` `platformVersion`, and registers two background jobs in `Module.cs`.
> 
> **Inventory change logging** (`LogChangesChangedEventHandler`) now enqueues `LogEntityChangesJobHandler` with a `LogEntityChangesJobPayload` carrying `OperationLog[]` instead of calling `BackgroundJob.Enqueue(() => LogEntityChangesInBackground(...))`. The new handler **awaits** `SaveChangesAsync`, which the PR notes fixes correct **CreatedBy** attribution via the platform’s user scope / `AsyncLocal`.
> 
> **Fulfillment center geo cache refresh** (`FulfillmentCenterChangedEventHandler`) enqueues `RecalculateFulfillmentCenterDistanceJobHandler` when geo-relevant changes occur, replacing the old `RecalculateFFDistance` Hangfire enqueue. Legacy **`[Obsolete]`** methods (`LogEntityChangesInBackground`, `RecalculateFFDistance`) remain with **unchanged signatures** so already-queued Hangfire jobs can still run; concurrent-execution guarding from Hangfire is not replicated (overlapping runs only repeat cache work).
> 
> Adds **`BackgroundJobEnqueueTests`** to assert enqueue behavior, handler execution, and that logging-disabled paths still reset last-modified without enqueueing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7d2471c29b077f7abdef31588018d08bafff3c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->