### PR TITLE
VCST-5656: fix deleting inventories of a deleted product

### DIFF
--- a/src/VirtoCommerce.InventoryModule.Data/Services/InventoryServiceImpl.cs
+++ b/src/VirtoCommerce.InventoryModule.Data/Services/InventoryServiceImpl.cs
@@ -26,6 +26,7 @@ public class InventoryServiceImpl(
         IInventoryService
 {
     private readonly IPlatformMemoryCache _platformMemoryCache = platformMemoryCache;
+    private readonly IEventPublisher _eventPublisher = eventPublisher;
 
     [Obsolete("Use GetAsync()", DiagnosticId = "VC0011", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public virtual async Task<IEnumerable<InventoryInfo>> GetByIdsAsync(string[] ids, string responseGroup = null)
@@ -75,6 +76,38 @@ public class InventoryServiceImpl(
             .SelectMany(x => x.Inventories)
             .Select(x => x.CloneTyped())
             .ToList();
+    }
+
+    public override async Task DeleteAsync(IList<string> ids, bool softDelete = false)
+    {
+        var models = await GetAsync(ids);
+
+        using var repository = repositoryFactory();
+
+        // Raise domain events before deletion
+        var changedEntries = models.Select(x => new GenericChangedEntry<InventoryInfo>(x, EntryState.Deleted)).ToList();
+        await _eventPublisher.Publish(EventFactory<InventoryChangingEvent>(changedEntries));
+
+        if (softDelete)
+        {
+            await SoftDelete(repository, ids);
+            await repository.UnitOfWork.CommitAsync();
+        }
+        else
+        {
+            var entities = await LoadEntities(repository, ids);
+            foreach (var entity in entities)
+            {
+                repository.Remove(entity);
+            }
+            await repository.UnitOfWork.CommitAsync();
+            await AfterDeleteAsync(models, changedEntries);
+        }
+
+        ClearCache(models);
+
+        // Raise domain events after deletion
+        await _eventPublisher.Publish(EventFactory<InventoryChangedEvent>(changedEntries));
     }
 
     protected override Task<IList<InventoryEntity>> LoadEntities(IRepository repository, IList<string> ids, string responseGroup)

--- a/tests/VirtoCommerce.InventoryModule.Tests/InventoryServiceDeleteTests.cs
+++ b/tests/VirtoCommerce.InventoryModule.Tests/InventoryServiceDeleteTests.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using VirtoCommerce.InventoryModule.Data.Model;
+using VirtoCommerce.InventoryModule.Data.Repositories;
+using VirtoCommerce.InventoryModule.Data.Services;
+using VirtoCommerce.Platform.Caching;
+using VirtoCommerce.Platform.Core.Caching;
+using VirtoCommerce.Platform.Core.Domain;
+using VirtoCommerce.Platform.Core.Events;
+using Xunit;
+
+namespace VirtoCommerce.InventoryModule.Tests;
+
+public class InventoryServiceDeleteTests
+{
+    private readonly Mock<IInventoryRepository> _repositoryMock = new();
+    private readonly List<InventoryEntity> _removedEntities = [];
+
+    /// <summary>
+    /// InventoryEntity has a concurrency token (<see cref="InventoryEntity.RowVersion"/>), and InventoryInfo does not
+    /// carry it. Deleting an entity built out of the model therefore leaves the token unset, EF adds it to the DELETE
+    /// predicate as `RowVersion IS NULL`, no row matches, and the commit throws DbUpdateConcurrencyException instead of
+    /// deleting the row. Deleting the entity loaded from the repository keeps the token intact.
+    /// The exception itself only shows up against a real rowversion column, so what is asserted here is the invariant
+    /// that prevents it: the entity handed to the repository for removal is the loaded one.
+    /// </summary>
+    [Fact]
+    public async Task DeleteAsync_RemovesEntityLoadedFromRepository_KeepingConcurrencyToken()
+    {
+        // Arrange
+        var entity = new InventoryEntity
+        {
+            Id = "inventory-1",
+            Sku = "product-1",
+            FulfillmentCenterId = "fulfillment-center-1",
+            InStockQuantity = 10,
+            RowVersion = [0, 0, 0, 0, 0, 0, 7, 209],
+        };
+
+        var service = GetInventoryService([entity]);
+
+        // Act
+        await service.DeleteAsync([entity.Id]);
+
+        // Assert
+        var removedEntity = Assert.Single(_removedEntities);
+        Assert.Same(entity, removedEntity);
+        Assert.NotNull(removedEntity.RowVersion);
+    }
+
+    private InventoryServiceImpl GetInventoryService(IList<InventoryEntity> entities)
+    {
+        _repositoryMock
+            .Setup(x => x.GetByIdsAsync(It.IsAny<IList<string>>(), It.IsAny<string>()))
+            .ReturnsAsync((IList<string> ids, string _) => entities.Where(x => ids.Contains(x.Id)).ToList());
+
+        _repositoryMock
+            .Setup(x => x.Remove(It.IsAny<InventoryEntity>()))
+            .Callback((InventoryEntity entity) => _removedEntities.Add(entity));
+
+        _repositoryMock
+            .Setup(x => x.UnitOfWork)
+            .Returns(Mock.Of<IUnitOfWork>());
+
+        var memoryCache = new MemoryCache(Options.Create(new MemoryCacheOptions()));
+        var platformMemoryCache = new PlatformMemoryCache(memoryCache, Options.Create(new CachingOptions()),
+            new Mock<ILogger<PlatformMemoryCache>>().Object);
+
+        return new InventoryServiceImpl(() => _repositoryMock.Object, platformMemoryCache, Mock.Of<IEventPublisher>());
+    }
+}


### PR DESCRIPTION
Deleting a catalog product that had an inventory row answered 409 DbUpdateConcurrencyException: the product was gone, but ProductChangedEventHandler failed and the inventory row survived as an orphan.

The base CrudService.DeleteAsync removes a stub built by FromModel, which cannot carry InventoryEntity.RowVersion because InventoryInfo has no such property. EF then put the unset concurrency token into the DELETE predicate (WHERE Id = @p0 AND RowVersion IS NULL), nothing matched it, and the commit threw. InventoryEntity is the only entity of this module with a concurrency token, and the handler added in VCST-5546 is the only caller of IInventoryService.DeleteAsync, so the defect had no way to surface before.

Override DeleteAsync to remove the entities loaded from the repository. The same defect is fixed platform-side; this override can go once the module moves onto that platform version.

## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5656
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Inventory_3.1006.0-pr-165-c226.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core delete behavior for the only concurrency-token entity in the module; incorrect removal logic could affect data integrity, but scope is narrow and covered by a targeted test.
> 
> **Overview**
> Fixes **409 `DbUpdateConcurrencyException`** when inventory rows are deleted after a product is removed (e.g. via `ProductChangedEventHandler` calling `IInventoryService.DeleteAsync`).
> 
> The base **`CrudService.DeleteAsync`** path removed a stub built from **`InventoryInfo`**, which cannot carry **`InventoryEntity.RowVersion`**. EF then generated a DELETE with **`RowVersion IS NULL`**, matched no rows, and failed the commit—leaving orphan inventory.
> 
> **`InventoryServiceImpl`** now **overrides `DeleteAsync`**: load entities with **`LoadEntities`**, **`Remove`** those tracked instances, publish changing/changed events, clear cache, and call **`AfterDeleteAsync`** on hard delete. A unit test asserts the repository receives the **same loaded entity** with **`RowVersion`** set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c226fad665eb719d27dea8e23718fcc61268dd73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->